### PR TITLE
Fix interface implementation mismatch for tabBarIOS

### DIFF
--- a/src/components/tabBarIOSRe.re
+++ b/src/components/tabBarIOSRe.re
@@ -20,9 +20,9 @@ let make
                 (
                   fun x =>
                     switch x {
-                    | `default => "default"
-                    | `lightContent => "light-content"
-                    | `darkContent => "dark-content"
+                    | `fill => "fill"
+                    | `center => "center"
+                    | `auto => "auto"
                     }
                 )
                 itemPositioning


### PR DESCRIPTION
Ran into a problem compiling the RNTester project. It was failing because the implementation for `tabBarIOS` did not match the interface for it. This tiny PR fixes it.