### PR TITLE
Fixed bindings for the Linking module.

### DIFF
--- a/src/linkingRe.re
+++ b/src/linkingRe.re
@@ -1,14 +1,14 @@
 external openURL : string => Js.Promise.t unit =
-  "openUrl" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+  "openURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
-external _canOpenUrl : string => Js.Promise.t Js.boolean =
-  "canOpenUrl" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+external _canOpenURL : string => Js.Promise.t Js.boolean =
+  "canOpenURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
-let canOpenUrl url =>
-  _canOpenUrl url |> Js.Promise.then_ (fun bool => Js.Promise.resolve (Js.to_bool bool));
+let canOpenURL url =>
+  _canOpenURL url |> Js.Promise.then_ (fun bool => Js.Promise.resolve (Js.to_bool bool));
 
-external getInitialUrl : unit => Js.Promise.t string =
-  "getInitialUrl" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+external getInitialURL : unit => Js.Promise.t string =
+  "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =
   "" [@@bs.scope "Linking"] [@@bs.module "react-native"];

--- a/src/linkingRe.re
+++ b/src/linkingRe.re
@@ -7,7 +7,7 @@ external _canOpenURL : string => Js.Promise.t Js.boolean =
 let canOpenURL url =>
   _canOpenURL url |> Js.Promise.then_ (fun bool => Js.Promise.resolve (Js.to_bool bool));
 
-external getInitialURL : unit => Js.Promise.t string =
+external getInitialURL : unit => Js.Promise.t (Js.Null.t string) =
   "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =

--- a/src/linkingRe.re
+++ b/src/linkingRe.re
@@ -7,8 +7,11 @@ external _canOpenURL : string => Js.Promise.t Js.boolean =
 let canOpenURL url =>
   _canOpenURL url |> Js.Promise.then_ (fun bool => Js.Promise.resolve (Js.to_bool bool));
 
-external getInitialURL : unit => Js.Promise.t (Js.Null.t string) =
+external _getInitialURL : unit => Js.Promise.t (Js.Null.t string) =
   "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+  
+let getInitialURL () => 
+  _getInitialURL () |> Js.Promise.then_ (fun stringOrNull => Js.Promise.resolve (Js.Null.to_opt stringOrNull));
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =
   "" [@@bs.scope "Linking"] [@@bs.module "react-native"];

--- a/src/linkingRe.rei
+++ b/src/linkingRe.rei
@@ -3,7 +3,7 @@ let canOpenURL: string => Js.Promise.t bool;
 external openURL : string => Js.Promise.t unit =
   "openURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
-external getInitialURL : unit => Js.Promise.t string =
+external getInitialURL : unit => Js.Promise.t (Js.Null.t string) =
   "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =

--- a/src/linkingRe.rei
+++ b/src/linkingRe.rei
@@ -1,10 +1,10 @@
-let canOpenUrl: string => Js.Promise.t bool;
+let canOpenURL: string => Js.Promise.t bool;
 
 external openURL : string => Js.Promise.t unit =
-  "openUrl" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+  "openURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
-external getInitialUrl : unit => Js.Promise.t string =
-  "getInitialUrl" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+external getInitialURL : unit => Js.Promise.t string =
+  "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =
   "" [@@bs.scope "Linking"] [@@bs.module "react-native"];

--- a/src/linkingRe.rei
+++ b/src/linkingRe.rei
@@ -3,8 +3,7 @@ let canOpenURL: string => Js.Promise.t bool;
 external openURL : string => Js.Promise.t unit =
   "openURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
 
-external getInitialURL : unit => Js.Promise.t (Js.Null.t string) =
-  "getInitialURL" [@@bs.scope "Linking"] [@@bs.module "react-native"];
+let getInitialURL : unit => Js.Promise.t (option string);
 
 external addEventListener : string => (Js.t {. url : string} => unit) => unit =
   "" [@@bs.scope "Linking"] [@@bs.module "react-native"];


### PR DESCRIPTION
This fixes wrong capitalization in the Linking module, which previously bound to the nonexistent openUrl, canOpenUrl, and getInitialUrl methods.