### PR TITLE
Fixes onScroll event type on ScrollView

### DIFF
--- a/src/RNEvent.re
+++ b/src/RNEvent.re
@@ -16,15 +16,56 @@ module NativeEvent = {
 
 module NativeLayoutEvent = {
   type t;
-  type layout = {x: float, y: float, width: float, height: float};
-  external _layout : t => Js.t 'a =
-    "nativeEvent" [@@bs.get];
+  type layout = {
+    x: float,
+    y: float,
+    width: float,
+    height: float
+  };
+  external _layout : t => Js.t 'a = "nativeEvent" [@@bs.get];
   let layout (t: t) => {
     let l = (_layout t)##layout;
     {x: l##x, y: l##y, width: l##width, height: l##height}
   };
 };
 
+module NativeScrollEvent = {
+  type t;
+  type point = {
+    x: float,
+    y: float
+  };
+  type size = {
+    width: float,
+    height: float
+  };
+  type contentInset = {
+    bottom: float,
+    top: float,
+    left: float,
+    right: float
+  };
+  external _nativeEvent : t => Js.t 'a = "nativeEvent" [@@bs.get];
+  let contentOffset (t: t) => {
+    let co = (_nativeEvent t)##contentOffset;
+    {x: co##x, y: co##y}
+  };
+  let contentSize (t: t) => {
+    let cs = (_nativeEvent t)##contentSize;
+    {width: cs##width, height: cs##height}
+  };
+  let layoutMeasurement (t: t) => {
+    let lm = (_nativeEvent t)##layoutMeasurement;
+    {width: lm##width, height: lm##height}
+  };
+  let contentInset (t: t) => {
+    let ci = (_nativeEvent t)##contentInset;
+    {bottom: ci##bottom, top: ci##top, left: ci##left, right: ci##right}
+  };
+};
+
 external nativeEvent : t => NativeEvent.t = "" [@@bs.get];
 
 external nativeLayoutEvent : t => NativeLayoutEvent.t = "nativeEvent" [@@bs.get];
+
+external nativeScrollEvent : t => NativeScrollEvent.t = "nativeEvent" [@@bs.get];

--- a/src/RNEvent.rei
+++ b/src/RNEvent.rei
@@ -2,24 +2,53 @@ type t;
 
 module NativeEvent: {
   type t;
-  let changedTouches : t => array (Js.t {..});
-  let identifier : t => int;
-  let locationX : t => float;
-  let locationY : t => float;
-  let pageX : t => float;
-  let pageY : t => float;
-  let target : t => Js.t {..};
-  let touches : t => array (Js.t {..});
+  let changedTouches: t => array (Js.t {..});
+  let identifier: t => int;
+  let locationX: t => float;
+  let locationY: t => float;
+  let pageX: t => float;
+  let pageY: t => float;
+  let target: t => Js.t {..};
+  let touches: t => array (Js.t {..});
   let timestamp: t => int;
   let data: t => string;
 };
 
+module NativeScrollEvent: {
+  type t;
+  type point = {
+    x: float,
+    y: float
+  };
+  type size = {
+    width: float,
+    height: float
+  };
+  type contentInset = {
+    bottom: float,
+    top: float,
+    left: float,
+    right: float
+  };
+  let contentOffset: t => point;
+  let contentSize: t => size;
+  let contentInset: t => contentInset;
+  let layoutMeasurement: t => size;
+};
+
 module NativeLayoutEvent: {
   type t;
-  type layout = {x: float, y: float, width: float, height: float};
+  type layout = {
+    x: float,
+    y: float,
+    width: float,
+    height: float
+  };
   let layout: t => layout;
 };
 
-let nativeEvent : t => NativeEvent.t;
+let nativeEvent: t => NativeEvent.t;
 
-let nativeLayoutEvent : t => NativeLayoutEvent.t;
+let nativeLayoutEvent: t => NativeLayoutEvent.t;
+
+let nativeScrollEvent: t => NativeScrollEvent.t;

--- a/src/components/animatedComponentsRe.rei
+++ b/src/components/animatedComponentsRe.rei
@@ -58,7 +58,7 @@ module ScrollView: {
     keyboardDismissMode::[ | `interactive | `none | `onDrag]? =>
     keyboardShouldPersistTaps::[ | `always | `handled | `never]? =>
     onContentSizeChange::((float, float) => unit)? =>
-    onScroll::(RNEvent.NativeEvent.t => unit)? =>
+    onScroll::(RNEvent.NativeScrollEvent.t => unit)? =>
     pagingEnabled::bool? =>
     refreshControl::ReasonReact.reactElement? =>
     scrollEnabled::bool? =>

--- a/src/components/scrollViewRe.re
+++ b/src/components/scrollViewRe.re
@@ -51,7 +51,7 @@ module type ScrollViewComponent = {
     keyboardDismissMode::[ | `none | `interactive | `onDrag]? =>
     keyboardShouldPersistTaps::[ | `always | `never | `handled]? =>
     onContentSizeChange::((float, float) => unit)? =>
-    onScroll::(RNEvent.NativeEvent.t => unit)? =>
+    onScroll::(RNEvent.NativeScrollEvent.t => unit)? =>
     pagingEnabled::bool? =>
     refreshControl::ReasonReact.reactElement? =>
     scrollEnabled::bool? =>

--- a/src/components/scrollViewRe.rei
+++ b/src/components/scrollViewRe.rei
@@ -51,7 +51,7 @@ module type ScrollViewComponent = {
     keyboardDismissMode::[ | `interactive | `none | `onDrag]? =>
     keyboardShouldPersistTaps::[ | `always | `handled | `never]? =>
     onContentSizeChange::((float, float) => unit)? =>
-    onScroll::(RNEvent.NativeEvent.t => unit)? =>
+    onScroll::(RNEvent.NativeScrollEvent.t => unit)? =>
     pagingEnabled::bool? =>
     refreshControl::ReasonReact.reactElement? =>
     scrollEnabled::bool? =>


### PR DESCRIPTION
Current implementation of _ScrollView.onScroll_ takes a callback function with event of type `RNEvent.NativeEvent.t` where every property of the callback event is `undefined`.

This PR fixes that by replacing the `onScroll` event type with a new module type `RNEvent.NativeScrollEvent` which coordinates with the implementation found [here](https://github.com/facebook/react-native/blob/master/React/Views/RCTScrollView.m#L87).