### PR TITLE
Add PixelRatio bindings

### DIFF
--- a/src/pixelRatioRe.re
+++ b/src/pixelRatioRe.re
@@ -1,1 +1,7 @@
-external get : unit => int = "get" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];
+external get : unit => float = "get" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];
+
+external getFontScale : unit => float = "getFontScale" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];
+
+external getPixelSizeForLayoutSize : int => int = "getPixelSizeForLayoutSize" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];
+
+external roundToNearestPixel : float => float = "roundToNearestPixel" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];

--- a/src/pixelRatioRe.re
+++ b/src/pixelRatioRe.re
@@ -1,0 +1,1 @@
+external get : unit => int = "get" [@@bs.scope "PixelRatio"] [@@bs.module "react-native"];

--- a/src/pixelRatioRe.rei
+++ b/src/pixelRatioRe.rei
@@ -1,1 +1,7 @@
-let get: unit => int;
+let get: unit => float;
+
+let getFontScale: unit => float;
+
+let getPixelSizeForLayoutSize: int => int;
+
+let roundToNearestPixel: float => float;

--- a/src/pixelRatioRe.rei
+++ b/src/pixelRatioRe.rei
@@ -1,0 +1,1 @@
+let get: unit => int;

--- a/src/reactNative.re
+++ b/src/reactNative.re
@@ -84,6 +84,8 @@ module NativeEventEmitter = NativeEventEmitterRe;
 
 module Platform = PlatformRe;
 
+module PixelRatio = PixelRatioRe;
+
 module StyleSheet = StyleSheetRe;
 
 module PanResponder = {


### PR DESCRIPTION
Adding bindings for the  [PixelRatio](https://facebook.github.io/react-native/docs/pixelratio.html) API

Example usage of the methods added are: 
```ocaml
PixelRatio.get ();
PixelRatio.getFontScale ();
PixelRatio.getPixelSizeForLayoutSize 401;
PixelRatio.roundToNearestPixel 8.4;

```