### PR TITLE
Fixes wrong binding for processColor

### DIFF
--- a/src/styleSheetRe.re
+++ b/src/styleSheetRe.re
@@ -27,4 +27,4 @@ let flatten styles => flatten t (Array.of_list styles);
  * colors as strings everywhere
  */
 external processColor : [ | `String string | `Number int] [@bs.unwrap] => string =
-  "processColor" [@@bs.module];
+  "processColor" [@@bs.module "react-native"];


### PR DESCRIPTION
Fixes
`Unable to resolve module 'processColor' from .../bs-react-native/src/styleSheetRe.js': Module does not exist in the module map`