### PR TITLE
Add local image support to imagebackground

### DIFF
--- a/RNTester/index.android.js
+++ b/RNTester/index.android.js
@@ -4,10 +4,8 @@
  * @flow
  */
 
-import { comp as App } from "../lib/js/RNTester/src/rNTesterApp.js";
-import React from "react";
-import {
-  AppRegistry
-} from 'react-native';
+import {comp as App} from '../lib/js/RNTester/src/RNTesterApp.js';
+import React from 'react';
+import {AppRegistry} from 'react-native';
 
 AppRegistry.registerComponent('RNTester', () => App);

--- a/RNTester/index.ios.js
+++ b/RNTester/index.ios.js
@@ -4,10 +4,8 @@
  * @flow
  */
 
-import { reactClass } from "./lib/js/src/rNTesterApp.js";
-import React from "react";
-import {
-  AppRegistry
-} from 'react-native';
+import {reactClass} from './lib/js/src/RNTesterApp.js';
+import React from 'react';
+import {AppRegistry} from 'react-native';
 
 AppRegistry.registerComponent('RNTester', () => reactClass);

--- a/src/components/imageBackgroundRe.re
+++ b/src/components/imageBackgroundRe.re
@@ -1,4 +1,5 @@
 open ImageRe;
+
 external view : ReasonReact.reactClass = "ImageBackground" [@@bs.module "react-native"];
 
 module Event = {
@@ -11,9 +12,16 @@ module Event = {
   external progress : t => progress = "nativeEvent" [@@bs.get];
 };
 
+type imageSource =
+  | URI Image.imageURISource
+  | Required PackagerRe.required
+  | Multiple (list Image.imageURISource);
+
 type rawImageSourceJS;
+
 external rawImageSourceJS : 'a => rawImageSourceJS = "%identity";
-  let make
+
+let make
     ::onError=?
     ::onLayout=?
     ::onLoad=?
@@ -42,47 +50,67 @@ external rawImageSourceJS : 'a => rawImageSourceJS = "%identity";
           "onLoad": from_opt onLoad,
           "onLoadEnd": from_opt onLoadEnd,
           "onLoadStart": from_opt onLoadStart,
-          "resizeMode": from_opt (UtilsRN.option_map (
-            fun x => switch x {
-              | `cover => "cover"
-              | `contain => "contain"
-              | `stretch => "stretch"
-              | `repeat => "repeat"
-              | `center => "center"
-              }
-            ) resizeMode),
-          "source": from_opt (UtilsRN.option_map (
-            fun (x: Image.imageSource) =>
-              switch x {
-              | URI x => rawImageSourceJS x
-              | Required x => rawImageSourceJS x
-              | Multiple x => rawImageSourceJS (Array.of_list x)
-            }
-          ) source),
+          "resizeMode":
+            from_opt (
+              UtilsRN.option_map
+                (
+                  fun x =>
+                    switch x {
+                    | `cover => "cover"
+                    | `contain => "contain"
+                    | `stretch => "stretch"
+                    | `repeat => "repeat"
+                    | `center => "center"
+                    }
+                )
+                resizeMode
+            ),
+          "source":
+            from_opt (
+              UtilsRN.option_map
+                (
+                  fun (x: imageSource) =>
+                    switch x {
+                    | URI x => rawImageSourceJS x
+                    | Required x => rawImageSourceJS x
+                    | Multiple x => rawImageSourceJS (Array.of_list x)
+                    }
+                )
+                source
+            ),
           "style": from_opt style,
           "imageStyle": from_opt imageStyle,
           "testID": from_opt testID,
-          "resizeMethod": from_opt (UtilsRN.option_map (
-              fun x =>
-                switch x {
-                | `auto => "auto"
-                | `resize => "resize"
-                | `scale => "scale"
-              }
-          ) resizeMethod),
+          "resizeMethod":
+            from_opt (
+              UtilsRN.option_map
+                (
+                  fun x =>
+                    switch x {
+                    | `auto => "auto"
+                    | `resize => "resize"
+                    | `scale => "scale"
+                    }
+                )
+                resizeMethod
+            ),
           "accessibilityLabel": from_opt accessibilityLabel,
           "accessible": from_opt (UtilsRN.optBoolToOptJsBoolean accessible),
           "blurRadius": from_opt blurRadius,
           "capInsets": from_opt capInsets,
-          "defaultSource": from_opt (UtilsRN.option_map (
-            fun (x: Image.defaultSource) =>
-              switch x {
-              | URI x => rawImageSourceJS x
-              | Required x => rawImageSourceJS x
-            }
-          ) defaultSource),
+          "defaultSource":
+            from_opt (
+              UtilsRN.option_map
+                (
+                  fun (x: Image.defaultSource) =>
+                    switch x {
+                    | URI x => rawImageSourceJS x
+                    | Required x => rawImageSourceJS x
+                    }
+                )
+                defaultSource
+            ),
           "onPartialLoad": from_opt onPartialLoad,
-          "onProgress":
-            from_opt (UtilsRN.option_map (fun x y => x (Event.progress y)) onProgress)
+          "onProgress": from_opt (UtilsRN.option_map (fun x y => x (Event.progress y)) onProgress)
         }
       );

--- a/src/components/imageBackgroundRe.re
+++ b/src/components/imageBackgroundRe.re
@@ -12,11 +12,6 @@ module Event = {
   external progress : t => progress = "nativeEvent" [@@bs.get];
 };
 
-type imageSource =
-  | URI Image.imageURISource
-  | Required PackagerRe.required
-  | Multiple (list Image.imageURISource);
-
 type rawImageSourceJS;
 
 external rawImageSourceJS : 'a => rawImageSourceJS = "%identity";
@@ -69,7 +64,7 @@ let make
             from_opt (
               UtilsRN.option_map
                 (
-                  fun (x: imageSource) =>
+                  fun (x: Image.imageSource) =>
                     switch x {
                     | URI x => rawImageSourceJS x
                     | Required x => rawImageSourceJS x

--- a/src/components/imageBackgroundRe.rei
+++ b/src/components/imageBackgroundRe.rei
@@ -8,11 +8,6 @@ module Event: {
   };
 };
 
-type imageSource =
-  | URI Image.imageURISource
-  | Required PackagerRe.required
-  | Multiple (list Image.imageURISource);
-
 let make:
   onError::(Event.error => unit)? =>
   onLayout::(RNEvent.NativeLayoutEvent.t => unit)? =>
@@ -20,7 +15,7 @@ let make:
   onLoadEnd::(unit => unit)? =>
   onLoadStart::(unit => unit)? =>
   resizeMode::[< | `center | `contain | `cover | `repeat | `stretch]? =>
-  source::imageSource? =>
+  source::Image.imageSource? =>
   style::StyleRe.t? =>
   imageStyle::StyleRe.t? =>
   testID::string? =>

--- a/src/components/imageBackgroundRe.rei
+++ b/src/components/imageBackgroundRe.rei
@@ -8,6 +8,11 @@ module Event: {
   };
 };
 
+type imageSource =
+  | URI Image.imageURISource
+  | Required PackagerRe.required
+  | Multiple (list Image.imageURISource);
+
 let make:
   onError::(Event.error => unit)? =>
   onLayout::(RNEvent.NativeLayoutEvent.t => unit)? =>
@@ -15,7 +20,7 @@ let make:
   onLoadEnd::(unit => unit)? =>
   onLoadStart::(unit => unit)? =>
   resizeMode::[< | `center | `contain | `cover | `repeat | `stretch]? =>
-  source::Image.imageSource? =>
+  source::imageSource? =>
   style::StyleRe.t? =>
   imageStyle::StyleRe.t? =>
   testID::string? =>


### PR DESCRIPTION
Adding missing type for `imageSource` in `ImageBackground`   
Now it can handle using local assets in `ImageBackground` just like we can with the `Image` component.

Example usage would be: 
```ocaml
<ImageBackground
        /* all the other props here */
        source=(Required (Packager.require "../static/img/image.jpg"))>
</ImageBackground>
```

This PR also fixes broken imports in the RNTester app which broke after the capitalization of the compiled .js files