### PR TITLE
Capitalize imports in RNTester app index.ios/android files

### DIFF
--- a/RNTester/index.android.js
+++ b/RNTester/index.android.js
@@ -4,10 +4,8 @@
  * @flow
  */
 
-import { comp as App } from "../lib/js/RNTester/src/rNTesterApp.js";
-import React from "react";
-import {
-  AppRegistry
-} from 'react-native';
+import {comp as App} from '../lib/js/RNTester/src/RNTesterApp.js';
+import React from 'react';
+import {AppRegistry} from 'react-native';
 
 AppRegistry.registerComponent('RNTester', () => App);

--- a/RNTester/index.ios.js
+++ b/RNTester/index.ios.js
@@ -4,10 +4,8 @@
  * @flow
  */
 
-import { reactClass } from "./lib/js/src/rNTesterApp.js";
-import React from "react";
-import {
-  AppRegistry
-} from 'react-native';
+import {reactClass} from './lib/js/src/RNTesterApp.js';
+import React from 'react';
+import {AppRegistry} from 'react-native';
 
 AppRegistry.registerComponent('RNTester', () => reactClass);


### PR DESCRIPTION
After `bs-platform` updated to  version 1.9.2 generated files were capitalized but imports were still referring to the camelCased name `rnTesterApp -> RNTesterApp` This PR fixed that in the tester app so we can run it.