### PR TITLE
Makes Animated.Scrollview.onScrollUpdate use NativeScrollEvent

### DIFF
--- a/src/components/animatedComponentsRe.re
+++ b/src/components/animatedComponentsRe.re
@@ -20,7 +20,7 @@ module Text =
   };
 
 module ScrollView = {
-  type callback = RNEvent.NativeEvent.t => unit;
+  type callback = RNEvent.NativeScrollEvent.t => unit;
   external wrapUpdaterShamelessly : AnimatedRe.animatedEvent => callback = "%identity";
   let onScrollUpdater ::x=? ::y=? ::native=false () =>
     wrapUpdaterShamelessly (

--- a/src/components/animatedComponentsRe.rei
+++ b/src/components/animatedComponentsRe.rei
@@ -5,7 +5,8 @@ module Image: ImageRe.ImageComponent;
 module Text: TextRe.TextComponent;
 
 module ScrollView: {
-  let onScrollUpdater: x::'a? => y::'b? => native::bool? => unit => RNEvent.NativeEvent.t => unit;
+  let onScrollUpdater:
+    x::'a? => y::'b? => native::bool? => unit => RNEvent.NativeScrollEvent.t => unit;
   type point = {
     x: float,
     y: float


### PR DESCRIPTION
This PR makes it possible to use the native driver when animating with view based on scroll in scrollview.

This needs to be a NativeScrollEvent as `ScrollView.onScroll` expect a function `RNEvent.NativeScrollEvent.t => unit`

Example
```
type state = {scrollY: AnimatedRe.Value.t};
// And inside render function
let onScroll = Animated.ScrollView.onScrollUpdater y::state.scrollY native::true (); // RNEvent.NativeScrollEvent.t => unit
<Animated.ScrollView scrollEventThrottle=16 onScroll>
    // Views inside scrollview
</Animated.ScrollView>
```