### PR TITLE
Fixing types of maximumValue and minimumValue from Slider component

### DIFF
--- a/src/components/sliderRe.re
+++ b/src/components/sliderRe.re
@@ -14,9 +14,9 @@ let convertImageSource src =>
 let make
     disabled::(disabled: option bool)=?
     maximumTrackTintColor::(maximumTrackTintColor: option string)=?
-    maximumValue::(maximumValue: option string)=?
+    maximumValue::(maximumValue: option float)=?
     minimumTrackTintColor::(minimumTrackTintColor: option string)=?
-    minimumValue::(minimumValue: option string)=?
+    minimumValue::(minimumValue: option float)=?
     onSlidingComplete::(onSlidingComplete: option (float => unit))=?
     onValueChange::(onValueChange: option (float => unit))=?
     step::(step: option float)=?

--- a/src/components/sliderRe.rei
+++ b/src/components/sliderRe.rei
@@ -1,9 +1,9 @@
 let make:
   disabled::bool? =>
   maximumTrackTintColor::string? =>
-  maximumValue::string? =>
+  maximumValue::float? =>
   minimumTrackTintColor::string? =>
-  minimumValue::string? =>
+  minimumValue::float? =>
   onSlidingComplete::(float => unit)? =>
   onValueChange::(float => unit)? =>
   step::float? =>


### PR DESCRIPTION
When using string, the runtime gives me a dynamic type error as the
following: "TypeError:expected dynamic type 'double',but had type
'string'"

This commit fixes this problem.