### PR TITLE
Add back react-reason as devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"url": "https://github.com/reasonml-community/bs-react-native.git"
 	},
 	"devDependencies": {
-		"bs-platform": "^2.0.0"
+		"bs-platform": "^2.0.0",
+		"reason-react": "^0.2.4"
 	},
 	"peerDependencies": {
 		"reason-react": "^0.2.4",


### PR DESCRIPTION
Otherwise, you clone the repo, do npm/yarn install and don't have the dep, so running "npm run build" fails.
That's what is happening in #98

Current master works probably because of travis cache on node_modules.
To prevent this issue not being seens, we should take a decision for a lock file. See #104