### PR TITLE
Fix invalid json in bsconfig.json

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -10,13 +10,13 @@
       "dir": "src",
       "subdirs": [
         {
-          "dir": "components",
+          "dir": "components"
         },
         {
           "dir": "private",
-          "public": [],
-        },
-      ],
+          "public": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Current json is not valid.
I think it's better to keep it valid.

I could set up [prettier](https://github.com/prettier/prettier) if you are interested, to prevent this kind of "issues".