### PR TITLE
Adding build information for react-native-scripts use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ AppRegistry.registerComponent('MyAwesomeProject', () => app);
 ```
 **Note:** Make sure that the first argument to `AppRegistry.registerComponent` is **your** correct project name.
 
+If you are using `react-native-scripts`, then you will need to modify `App.js` to be like this
+```js
+import { app } from "./lib/js/re/app.js";
+
+export default app;
+```
+
 8. Now go to a new tab and start your app with `react-native run-ios` or `react-native run-android`.
 
 9. Great you are all set up! Check the source of `bs-react-native` to find out more about the implemented APIs and Components. If you get stuck just ask on our [Discord Server](https://discord.gg/reasonml)! Happy Hacking!


### PR DESCRIPTION
I created a test project using the create-react-native-app and tried integrating with Reason. However, I found that the new script for create-react-native-app does not contain an `index.ios.js` or `index.android.js`. New projects are setup with an `App.js` that is imported into the react-native-scripts [here](https://github.com/react-community/create-react-native-app/blob/master/react-native-scripts/src/bin/crna-entry.js). To work with this, I changed the App.js file to export the transpiled js. I thought updating the docs might help others if they run into this.