### PR TITLE
Fixing value mapping for flexbox align properties

### DIFF
--- a/lib/js/src/style.js
+++ b/lib/js/src/style.js
@@ -44,10 +44,10 @@ function alignContent(v) {
   var tmp;
   switch (v) {
     case 0 : 
-        tmp = "flex-start";
+        tmp = "flexStart";
         break;
     case 1 : 
-        tmp = "flex-end";
+        tmp = "flexEnd";
         break;
     case 2 : 
         tmp = "center";
@@ -56,10 +56,10 @@ function alignContent(v) {
         tmp = "stretch";
         break;
     case 4 : 
-        tmp = "space-around";
+        tmp = "spaceAround";
         break;
     case 5 : 
-        tmp = "space-between";
+        tmp = "spaceBetween";
         break;
     
   }
@@ -73,10 +73,10 @@ function alignItems(v) {
   var tmp;
   switch (v) {
     case 0 : 
-        tmp = "flex-start";
+        tmp = "flexStart";
         break;
     case 1 : 
-        tmp = "flex-end";
+        tmp = "flexEnd";
         break;
     case 2 : 
         tmp = "center";

--- a/src/style.re
+++ b/src/style.re
@@ -92,12 +92,12 @@ let alignContent = (v) =>
   stringStyle(
     "alignContent",
     switch v {
-    | FlexStart => "flex-start"
-    | FlexEnd => "flex-end"
+    | FlexStart => "flexStart"
+    | FlexEnd => "flexEnd"
     | Center => "center"
     | Stretch => "stretch"
-    | SpaceAround => "space-around"
-    | SpaceBetween => "space-between"
+    | SpaceAround => "spaceAround"
+    | SpaceBetween => "spaceBetween"
     }
   );
 
@@ -112,8 +112,8 @@ let alignItems = (v) =>
   stringStyle(
     "alignItems",
     switch v {
-    | FlexStart => "flex-start"
-    | FlexEnd => "flex-end"
+    | FlexStart => "flexStart"
+    | FlexEnd => "flexEnd"
     | Center => "center"
     | Stretch => "stretch"
     | Baseline => "baseline"


### PR DESCRIPTION
The values the variants for Flexbox align methods map to are not recognized by the react-native style api. They should be camelCased rather than snake cased (like the web implementation of flexbox does). 