### PR TITLE
Add Animated styles example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,38 @@ let styles =
 <View style=styles##wrapper />;
 ```
 
-## Toubleshooting
+For animations:
+```reason
+open BsReactNative;
+
+[...]
+type state = {animatedValue: Animated.Value.t};
+let component = ReasonReact.reducerComponent("Example");
+
+initialState: () => {animatedValue: Animated.Value.create((-100.))},
+
+/* Start animation in method */
+Animated.CompositeAnimation.start(
+  Animated.Timing.animate(
+    ~value=state.animatedValue,
+    ~toValue=`raw(0.),
+    ()
+  ),
+  ()
+);
+[...]
+
+/* Styles with an animated value */
+
+<Animated.View
+  style=Style.(style([flexDirection(Column), backgroundColor("#6698FF"), top(Animated(state.animatedValue))]))
+  )
+/>;
+
+```
+
+
+## Troubleshooting
 
 ### `Native module cannot be null` with create-react-native-app
 


### PR DESCRIPTION
An addition to the README to illustrate how the `Animated` type can be used in `styles`.

Added additional methods to present the `Animated` type within a relevant context instead of just presenting it on it's own.