### PR TITLE
creating accessory type that includes section to match react-native s…

### DIFF
--- a/lib/js/src/components/sectionList.js
+++ b/lib/js/src/components/sectionList.js
@@ -55,10 +55,8 @@ function separatorComponent(reSeparatorComponent, jsSeparatorProps) {
             ]);
 }
 
-function renderAccessoryView(renderer) {
-  return (function (section) {
-      return renderer(jsSectionToSection(section));
-    });
+function renderAccessoryView(reRenderAccessory, jsRenderAccessory) {
+  return Curry._1(reRenderAccessory, /* record */[/* section */jsSectionToSection(jsRenderAccessory.section)]);
 }
 
 function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEmptyComponent, listFooterComponent, listHeaderComponent, sectionSeparatorComponent, extraData, initialNumToRender, onEndReached, onEndReachedThreshold, onViewableItemsChanged, onRefresh, refreshing, renderSectionHeader, renderSectionFooter, stickySectionHeadersEnabled, _children) {

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -12,7 +12,8 @@ and jsRenderBag('item) = {
   "index": int,
   "section": jsSection('item),
   "separators": {. "highlight": unit => unit, "unhighlight": unit => unit}
-};
+}
+and jsRenderAccessory('item) = {. "section": jsSection('item)};
 
 type jsSeparatorProps('item) = {
   .
@@ -105,11 +106,15 @@ type viewToken('item) = {
   "section": section('item)
 };
 
-type renderAccessoryView('item) =
-  [@bs] (jsSection('item) => ReasonReact.reactElement);
+type renderAccessory('item) = {section: section('item)};
 
-let renderAccessoryView = (renderer) =>
-  [@bs] ((section) => [@bs] renderer(jsSectionToSection(section)));
+type renderAccessoryView('item) = jsRenderAccessory('item) => ReasonReact.reactElement;
+
+let renderAccessoryView =
+    (reRenderAccessory: renderAccessory('item) => ReasonReact.reactElement)
+    : renderAccessoryView('item) =>
+  (jsRenderAccessory: jsRenderAccessory('item)) =>
+    reRenderAccessory({section: jsSectionToSection(jsRenderAccessory##section)});
 
 let make:
   (

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -12,8 +12,7 @@ and jsRenderBag('item) = {
   "index": int,
   "section": jsSection('item),
   "separators": {. "highlight": unit => unit, "unhighlight": unit => unit}
-}
-and jsRenderAccessory('item) = {. "section": jsSection('item)};
+};
 
 type jsSeparatorProps('item) = {
   .
@@ -105,6 +104,8 @@ type viewToken('item) = {
   "isViewable": Js.boolean,
   "section": section('item)
 };
+
+type jsRenderAccessory('item) = {. "section": jsSection('item)};
 
 type renderAccessory('item) = {section: section('item)};
 

--- a/src/components/sectionList.rei
+++ b/src/components/sectionList.rei
@@ -8,9 +8,6 @@ and section('item) = {
   data: array('item),
   key: option(string),
   renderItem: option((renderBag('item) => ReasonReact.reactElement))
-}
-and renderAccessory('item) = {
-  section: section('item)
 };
 
 let section:
@@ -43,6 +40,8 @@ type separatorComponent('item);
 
 let separatorComponent:
   (separatorProps('item) => ReasonReact.reactElement) => separatorComponent('item);
+
+type renderAccessory('item) = {section: section('item)};
 
 type renderAccessoryView('item);
 

--- a/src/components/sectionList.rei
+++ b/src/components/sectionList.rei
@@ -8,6 +8,9 @@ and section('item) = {
   data: array('item),
   key: option(string),
   renderItem: option((renderBag('item) => ReasonReact.reactElement))
+}
+and renderAccessory('item) = {
+  section: section('item)
 };
 
 let section:
@@ -44,8 +47,7 @@ let separatorComponent:
 type renderAccessoryView('item);
 
 let renderAccessoryView:
-  ([@bs] (section('item) => ReasonReact.reactElement)) =>
-  renderAccessoryView('item);
+  (renderAccessory('item) => ReasonReact.reactElement) => renderAccessoryView('item);
 
 type viewToken('item) = {
   .


### PR DESCRIPTION
When using SectionList.re I hit the problem of RenderAccessoryView always having section as undefined.

This is the definition in react-native

```javascript
 renderSectionHeader?: ?(info: {section: SectionT}) => ?React.Element<any>,
```
They however don't define any object that only includes section, so I assume they are simply referring to the renderBag object, but discarding all items but section. 

I created a matching type to catch the Js object and return it, as I feel it increases readability of how to use it.

example use:
```
let renderHeader = (info: SectionList.renderAccessory(State.FriendRow.t)) => {
        let section = info.section;
        let sectionKey = section.key;
        switch sectionKey {
        | Some(key) => <View> <Text value=key /> </View>
        | None => ReasonReact.nullElement
        }
      };
<SectionList
      ....
      renderSectionHeader=(SectionList.renderAccessoryView(renderHeader)) 
/>
```
