### PR TITLE
TextInput (returnKeyType)

### DIFF
--- a/lib/js/src/components/textInput.js
+++ b/lib/js/src/components/textInput.js
@@ -115,7 +115,7 @@ function make(accessibilityLabel, accessible, hitSlop, onAccessibilityTap, onLay
                         if (x >= -504773703) {
                           return "google";
                         } else {
-                          return "done_";
+                          return "done";
                         }
                       } else if (x >= -867136184) {
                         return "send";

--- a/src/components/textInput.re
+++ b/src/components/textInput.re
@@ -135,7 +135,7 @@ let make =
                 UtilsRN.option_map(
                   (x) =>
                     switch x {
-                    | `done_ => "done_"
+                    | `done_ => "done"
                     | `go => "go"
                     | `next => "next"
                     | `search => "search"


### PR DESCRIPTION
This PR allows to use `done_` type variant (component: `TextInput`, property: `returnKeyType`).

RN docs:
https://facebook.github.io/react-native/docs/textinput.html#returnkeytype