### PR TITLE
Fix callback on Animated Value 

### DIFF
--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -245,7 +245,8 @@ module Interpolation = {
 
 module Value = {
   type t;
-  type callback = float => unit;
+  type jsValue = {. "value": float};
+  type callback = jsValue => unit;
   [@bs.new] [@bs.scope "Animated"] [@bs.module "react-native"] external create : float => t =
     "Value";
   [@bs.send] external setValue : (t, float) => unit = "setValue";

--- a/src/animatedRe.rei
+++ b/src/animatedRe.rei
@@ -33,7 +33,8 @@ module Interpolation: {
 
 module Value: {
   type t;
-  type callback = float => unit;
+  type jsValue = {. "value": float};
+  type callback = jsValue => unit;
   let create: float => t;
   let setValue: (t, float) => unit;
   let setOffset: (t, float) => unit;


### PR DESCRIPTION
I was adding an listener to an animated value and notice that the wrong type was defined in Animate.Value. This fixes the problem. I had to change this in the Animated source code to make this work for my project. Let me know if something is missing. This is my first PR to the reason community. 😄 