### PR TITLE
Expose more of ScrollView's props on SectionList

### DIFF
--- a/lib/js/src/components/sectionList.js
+++ b/lib/js/src/components/sectionList.js
@@ -3,6 +3,7 @@
 
 var $$Array = require("bs-platform/lib/js/array.js");
 var Curry = require("bs-platform/lib/js/curry.js");
+var Js_mapperRt = require("bs-platform/lib/js/js_mapperRt.js");
 var ReasonReact = require("reason-react/lib/js/src/ReasonReact.js");
 var Js_primitive = require("bs-platform/lib/js/js_primitive.js");
 var Js_undefined = require("bs-platform/lib/js/js_undefined.js");
@@ -59,7 +60,45 @@ function renderAccessoryView(reRenderAccessory, jsRenderAccessory) {
   return Curry._1(reRenderAccessory, /* record */[/* section */jsSectionToSection(jsRenderAccessory.section)]);
 }
 
-function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEmptyComponent, listFooterComponent, listHeaderComponent, sectionSeparatorComponent, extraData, initialNumToRender, onEndReached, onEndReachedThreshold, onViewableItemsChanged, onRefresh, refreshing, renderSectionHeader, renderSectionFooter, stickySectionHeadersEnabled, _children) {
+var jsMapperConstantArray = /* array */[
+  /* tuple */[
+    -922086728,
+    "none"
+  ],
+  /* tuple */[
+    -453364557,
+    "onDrag"
+  ],
+  /* tuple */[
+    1012481506,
+    "interactive"
+  ]
+];
+
+function keyboardDismissModeToJs(param) {
+  return Js_mapperRt.binarySearch(3, param, jsMapperConstantArray);
+}
+
+var jsMapperConstantArray$1 = /* array */[
+  /* tuple */[
+    -975851588,
+    "handled"
+  ],
+  /* tuple */[
+    -958984497,
+    "always"
+  ],
+  /* tuple */[
+    422592140,
+    "never"
+  ]
+];
+
+function keyboardShouldPersistTapsToJs(param) {
+  return Js_mapperRt.binarySearch(3, param, jsMapperConstantArray$1);
+}
+
+function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEmptyComponent, listFooterComponent, listHeaderComponent, sectionSeparatorComponent, extraData, initialNumToRender, onEndReached, onEndReachedThreshold, onViewableItemsChanged, onRefresh, refreshing, renderSectionHeader, renderSectionFooter, stickySectionHeadersEnabled, keyboardDismissMode, keyboardShouldPersistTaps, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, _children) {
   return ReasonReact.wrapJsForReason(ReactNative.SectionList, {
               sections: sections,
               renderItem: renderItem,
@@ -78,7 +117,11 @@ function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEm
               refreshing: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(refreshing)),
               renderSectionHeader: Js_undefined.fromOption(renderSectionHeader),
               renderSectionFooter: Js_undefined.fromOption(renderSectionFooter),
-              stickySectionHeadersEnabled: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(stickySectionHeadersEnabled))
+              stickySectionHeadersEnabled: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(stickySectionHeadersEnabled)),
+              keyboardDismissMode: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardDismissModeToJs, keyboardDismissMode)),
+              keyboardShouldPersistTaps: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardShouldPersistTapsToJs, keyboardShouldPersistTaps)),
+              showsHorizontalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsHorizontalScrollIndicator)),
+              showsVerticalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator))
             }, _children);
 }
 

--- a/lib/js/src/components/sectionList.js
+++ b/lib/js/src/components/sectionList.js
@@ -98,7 +98,7 @@ function keyboardShouldPersistTapsToJs(param) {
   return Js_mapperRt.binarySearch(3, param, jsMapperConstantArray$1);
 }
 
-function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEmptyComponent, listFooterComponent, listHeaderComponent, sectionSeparatorComponent, extraData, initialNumToRender, onEndReached, onEndReachedThreshold, onViewableItemsChanged, onRefresh, refreshing, renderSectionHeader, renderSectionFooter, stickySectionHeadersEnabled, keyboardDismissMode, keyboardShouldPersistTaps, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, _children) {
+function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEmptyComponent, listFooterComponent, listHeaderComponent, sectionSeparatorComponent, extraData, initialNumToRender, onEndReached, onEndReachedThreshold, onViewableItemsChanged, onRefresh, refreshing, renderSectionHeader, renderSectionFooter, stickySectionHeadersEnabled, keyboardDismissMode, keyboardShouldPersistTaps, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, getItemLayout, _children) {
   return ReasonReact.wrapJsForReason(ReactNative.SectionList, {
               sections: sections,
               renderItem: renderItem,
@@ -121,7 +121,10 @@ function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEm
               keyboardDismissMode: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardDismissModeToJs, keyboardDismissMode)),
               keyboardShouldPersistTaps: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardShouldPersistTapsToJs, keyboardShouldPersistTaps)),
               showsHorizontalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsHorizontalScrollIndicator)),
-              showsVerticalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator))
+              showsVerticalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator)),
+              getItemLayout: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map((function (f, data, index) {
+                          return Curry._2(f, data === undefined ? /* None */0 : [data], index);
+                        }), getItemLayout))
             }, _children);
 }
 

--- a/lib/js/src/components/sectionList.js
+++ b/lib/js/src/components/sectionList.js
@@ -117,12 +117,12 @@ function make(sections, renderItem, keyExtractor, itemSeparatorComponent, listEm
               refreshing: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(refreshing)),
               renderSectionHeader: Js_undefined.fromOption(renderSectionHeader),
               renderSectionFooter: Js_undefined.fromOption(renderSectionFooter),
-              stickySectionHeadersEnabled: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(stickySectionHeadersEnabled)),
-              keyboardDismissMode: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardDismissModeToJs, keyboardDismissMode)),
-              keyboardShouldPersistTaps: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map(keyboardShouldPersistTapsToJs, keyboardShouldPersistTaps)),
-              showsHorizontalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsHorizontalScrollIndicator)),
-              showsVerticalScrollIndicator: Js_undefined.from_opt(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator)),
-              getItemLayout: Js_undefined.from_opt(UtilsRN$BsReactNative.option_map((function (f, data, index) {
+              stickySectionHeadersEnabled: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(stickySectionHeadersEnabled)),
+              keyboardDismissMode: Js_undefined.fromOption(UtilsRN$BsReactNative.option_map(keyboardDismissModeToJs, keyboardDismissMode)),
+              keyboardShouldPersistTaps: Js_undefined.fromOption(UtilsRN$BsReactNative.option_map(keyboardShouldPersistTapsToJs, keyboardShouldPersistTaps)),
+              showsHorizontalScrollIndicator: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsHorizontalScrollIndicator)),
+              showsVerticalScrollIndicator: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator)),
+              getItemLayout: Js_undefined.fromOption(UtilsRN$BsReactNative.option_map((function (f, data, index) {
                           return Curry._2(f, data === undefined ? /* None */0 : [data], index);
                         }), getItemLayout))
             }, _children);

--- a/lib/js/src/datePickerAndroid.js
+++ b/lib/js/src/datePickerAndroid.js
@@ -36,8 +36,8 @@ function open_(date, minDate, maxDate, $staropt$star, _) {
   }
   return ReactNative.DatePickerAndroid.open({
                 date: date,
-                minDate: Js_null_undefined.from_opt(minDate),
-                maxDate: Js_null_undefined.from_opt(maxDate),
+                minDate: Js_null_undefined.fromOption(minDate),
+                maxDate: Js_null_undefined.fromOption(maxDate),
                 mode: tmp
               }).then((function (resp) {
                 return Promise.resolve(action(resp));

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -171,6 +171,14 @@ let make:
     ~keyboardShouldPersistTaps: keyboardShouldPersistTaps=?,
     ~showsHorizontalScrollIndicator: bool=?,
     ~showsVerticalScrollIndicator: bool=?,
+    ~getItemLayout: (option(array('item)), int) =>
+                    {
+                      .
+                      "length": int,
+                      "offset": int,
+                      "index": int,
+                    }
+                      =?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(
@@ -201,6 +209,7 @@ let make:
     ~keyboardShouldPersistTaps=?,
     ~showsHorizontalScrollIndicator=?,
     ~showsVerticalScrollIndicator=?,
+    ~getItemLayout=?,
     _children,
   ) =>
     ReasonReact.wrapJsForReason(
@@ -248,6 +257,13 @@ let make:
             "showsVerticalScrollIndicator":
               from_opt(
                 UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
+              ),
+            "getItemLayout":
+              from_opt(
+                UtilsRN.option_map(
+                  (f, data, index) => f(Js.Undefined.to_opt(data), index),
+                  getItemLayout,
+                ),
               ),
           }
         ),

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -237,31 +237,31 @@ let make:
             "renderSectionHeader": fromOption(renderSectionHeader),
             "renderSectionFooter": fromOption(renderSectionFooter),
             "stickySectionHeadersEnabled":
-              from_opt(
+              fromOption(
                 UtilsRN.optBoolToOptJsBoolean(stickySectionHeadersEnabled),
               ),
             "keyboardDismissMode":
-              from_opt(
+              fromOption(
                 keyboardDismissMode
                 |> UtilsRN.option_map(keyboardDismissModeToJs),
               ),
             "keyboardShouldPersistTaps":
-              from_opt(
+              fromOption(
                 keyboardShouldPersistTaps
                 |> UtilsRN.option_map(keyboardShouldPersistTapsToJs),
               ),
             "showsHorizontalScrollIndicator":
-              from_opt(
+              fromOption(
                 UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
               ),
             "showsVerticalScrollIndicator":
-              from_opt(
+              fromOption(
                 UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
               ),
             "getItemLayout":
-              from_opt(
+              fromOption(
                 UtilsRN.option_map(
-                  (f, data, index) => f(Js.Undefined.to_opt(data), index),
+                  (f, data, index) => f(Js.Undefined.toOption(data), index),
                   getItemLayout,
                 ),
               ),

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -136,6 +136,12 @@ let renderAccessoryView =
       section: jsSectionToSection(jsRenderAccessory##section),
     });
 
+[@bs.deriving jsConverter]
+type keyboardDismissMode = [ | `none | `interactive | `onDrag];
+
+[@bs.deriving jsConverter]
+type keyboardShouldPersistTaps = [ | `always | `never | `handled];
+
 let make:
   (
     ~sections: sections('item),
@@ -161,6 +167,10 @@ let make:
     ~renderSectionHeader: renderAccessoryView('item)=?,
     ~renderSectionFooter: renderAccessoryView('item)=?,
     ~stickySectionHeadersEnabled: bool=?,
+    ~keyboardDismissMode: keyboardDismissMode=?,
+    ~keyboardShouldPersistTaps: keyboardShouldPersistTaps=?,
+    ~showsHorizontalScrollIndicator: bool=?,
+    ~showsVerticalScrollIndicator: bool=?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(
@@ -187,6 +197,10 @@ let make:
     ~renderSectionHeader=?,
     ~renderSectionFooter=?,
     ~stickySectionHeadersEnabled=?,
+    ~keyboardDismissMode=?,
+    ~keyboardShouldPersistTaps=?,
+    ~showsHorizontalScrollIndicator=?,
+    ~showsVerticalScrollIndicator=?,
     _children,
   ) =>
     ReasonReact.wrapJsForReason(
@@ -214,8 +228,26 @@ let make:
             "renderSectionHeader": fromOption(renderSectionHeader),
             "renderSectionFooter": fromOption(renderSectionFooter),
             "stickySectionHeadersEnabled":
-              fromOption(
+              from_opt(
                 UtilsRN.optBoolToOptJsBoolean(stickySectionHeadersEnabled),
+              ),
+            "keyboardDismissMode":
+              from_opt(
+                keyboardDismissMode
+                |> UtilsRN.option_map(keyboardDismissModeToJs),
+              ),
+            "keyboardShouldPersistTaps":
+              from_opt(
+                keyboardShouldPersistTaps
+                |> UtilsRN.option_map(keyboardShouldPersistTapsToJs),
+              ),
+            "showsHorizontalScrollIndicator":
+              from_opt(
+                UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
+              ),
+            "showsVerticalScrollIndicator":
+              from_opt(
+                UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
               ),
           }
         ),

--- a/src/components/sectionList.rei
+++ b/src/components/sectionList.rei
@@ -93,6 +93,7 @@ let make:
     ~keyboardShouldPersistTaps: [ | `always | `never | `handled]=?,
     ~showsHorizontalScrollIndicator: bool=?,
     ~showsVerticalScrollIndicator: bool=?,
+    ~getItemLayout: (option(array('item)), int) => {. "length": int, "offset": int, "index": int}=?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(

--- a/src/components/sectionList.rei
+++ b/src/components/sectionList.rei
@@ -2,12 +2,16 @@ type renderBag('item) = {
   item: 'item,
   index: int,
   section: section('item),
-  separators: {. "highlight": unit => unit, "unhighlight": unit => unit}
+  separators: {
+    .
+    "highlight": unit => unit,
+    "unhighlight": unit => unit,
+  },
 }
 and section('item) = {
   data: array('item),
   key: option(string),
-  renderItem: option((renderBag('item) => ReasonReact.reactElement))
+  renderItem: option(renderBag('item) => ReasonReact.reactElement),
 };
 
 let section:
@@ -25,7 +29,7 @@ type separatorProps('item) = {
   leadingSection: option(section('item)),
   section: section('item),
   trailingItem: option('item),
-  trailingSection: option(section('item))
+  trailingSection: option(section('item)),
 };
 
 type sections('item);
@@ -34,19 +38,22 @@ let sections: array(section('item)) => sections('item);
 
 type renderItem('item);
 
-let renderItem: (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
+let renderItem:
+  (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
 
 type separatorComponent('item);
 
 let separatorComponent:
-  (separatorProps('item) => ReasonReact.reactElement) => separatorComponent('item);
+  (separatorProps('item) => ReasonReact.reactElement) =>
+  separatorComponent('item);
 
 type renderAccessory('item) = {section: section('item)};
 
 type renderAccessoryView('item);
 
 let renderAccessoryView:
-  (renderAccessory('item) => ReasonReact.reactElement) => renderAccessoryView('item);
+  (renderAccessory('item) => ReasonReact.reactElement) =>
+  renderAccessoryView('item);
 
 type viewToken('item) = {
   .
@@ -54,7 +61,7 @@ type viewToken('item) = {
   "isViewable": Js.boolean,
   "item": 'item,
   "key": string,
-  "section": section('item)
+  "section": section('item),
 };
 
 let make:
@@ -74,7 +81,7 @@ let make:
     ~onViewableItemsChanged: {
                                .
                                "changed": array(viewToken('item)),
-                               "viewableItems": array(viewToken('item))
+                               "viewableItems": array(viewToken('item)),
                              }
                                =?,
     ~onRefresh: unit => unit=?,
@@ -82,6 +89,14 @@ let make:
     ~renderSectionHeader: renderAccessoryView('item)=?,
     ~renderSectionFooter: renderAccessoryView('item)=?,
     ~stickySectionHeadersEnabled: bool=?,
+    ~keyboardDismissMode: [ | `none | `interactive | `onDrag]=?,
+    ~keyboardShouldPersistTaps: [ | `always | `never | `handled]=?,
+    ~showsHorizontalScrollIndicator: bool=?,
+    ~showsVerticalScrollIndicator: bool=?,
     array(ReasonReact.reactElement)
   ) =>
-  ReasonReact.component(ReasonReact.stateless, ReasonReact.noRetainedProps, unit);
+  ReasonReact.component(
+    ReasonReact.stateless,
+    ReasonReact.noRetainedProps,
+    unit,
+  );

--- a/src/datePickerAndroid.re
+++ b/src/datePickerAndroid.re
@@ -52,8 +52,8 @@ external _open : optsJs => Js.Promise.t(responseJs) = "open";
 let open_ = (~date: Js.Date.t, ~minDate=?, ~maxDate=?, ~mode=Default, ()) =>
   _open({
     "date": date,
-    "minDate": Js.Nullable.from_opt(minDate),
-    "maxDate": Js.Nullable.from_opt(maxDate),
+    "minDate": Js.Nullable.fromOption(minDate),
+    "maxDate": Js.Nullable.fromOption(maxDate),
     "mode":
       switch (mode) {
       | Default => "default"


### PR DESCRIPTION
SectionList should contain all of ScrollView's props according to the [docs](https://facebook.github.io/react-native/docs/sectionlist.html). We had added some but this PR adds more. It would be nice to add all of them but I didn't have time.

Additionally sneaks in a syntax change to fix deprecation warnings in DatePickerAndroid.