### PR TITLE
Adds bindings for WebView methods

### DIFF
--- a/lib/js/src/components/webView.js
+++ b/lib/js/src/components/webView.js
@@ -127,7 +127,31 @@ function contentInsets(prim, prim$1, prim$2, prim$3, _) {
   return tmp;
 }
 
+function goForward(prim) {
+  prim.goForward();
+  return /* () */0;
+}
+
+function goBack(prim) {
+  prim.goBack();
+  return /* () */0;
+}
+
+function reload(prim) {
+  prim.reload();
+  return /* () */0;
+}
+
+function stopLoading(prim) {
+  prim.stopLoading();
+  return /* () */0;
+}
+
 exports.source = source;
 exports.contentInsets = contentInsets;
+exports.goForward = goForward;
+exports.goBack = goBack;
+exports.reload = reload;
+exports.stopLoading = stopLoading;
 exports.make = make;
 /* ReasonReact Not a pure module */

--- a/src/components/webView.re
+++ b/src/components/webView.re
@@ -34,6 +34,14 @@ external contentInsets :
   contentInsets =
   "";
 
+[@bs.send] external goForward : ReasonReact.reactRef => unit = "";
+
+[@bs.send] external goBack : ReasonReact.reactRef => unit = "";
+
+[@bs.send] external reload : ReasonReact.reactRef => unit = "";
+
+[@bs.send] external stopLoading : ReasonReact.reactRef => unit = "";
+
 let make =
     (
       ~source=?,

--- a/src/components/webView.rei
+++ b/src/components/webView.rei
@@ -20,6 +20,14 @@ type contentInsets;
 let contentInsets:
   (~top: int=?, ~left: int=?, ~bottom: int=?, ~right: int=?, unit) => contentInsets;
 
+let goForward: ReasonReact.reactRef => unit;
+
+let goBack: ReasonReact.reactRef => unit;
+
+let reload: ReasonReact.reactRef => unit;
+
+let stopLoading: ReasonReact.reactRef => unit;
+
 let make:
   (
     ~source: source=?,


### PR DESCRIPTION
Adds bindings for `goForward()`, `goBack()`, `reload()` and `stopLoading()` on WebView.
These methods are still missing in the React-Native documentation but here is a PR to fix that https://github.com/facebook/react-native-website/pull/363

