### PR TITLE
Add sourceHtml and rename source to sourceUri in WebView bindings

### DIFF
--- a/RNTester/src/examples/WebViewExample.re
+++ b/RNTester/src/examples/WebViewExample.re
@@ -13,7 +13,7 @@ let examples: array(Example.t) =
         title: "Example.com",
         description: None,
         render: () => {
-          let source = WebView.source(~uri="https://example.com", ());
+          let source = WebView.sourceUri(~uri="https://example.com", ());
           <View
             style=(
               style([backgroundColor(String("#527FE4")), padding(Pt(5.))])

--- a/lib/js/src/components/webView.js
+++ b/lib/js/src/components/webView.js
@@ -93,7 +93,7 @@ function make(source, style, renderError, renderLoading, onError, onLoad, onLoad
     });
 }
 
-function source(prim, prim$1, prim$2, prim$3, _) {
+function sourceUri(prim, prim$1, prim$2, prim$3, _) {
   var tmp = { };
   if (prim) {
     tmp.uri = prim[0];
@@ -106,6 +106,17 @@ function source(prim, prim$1, prim$2, prim$3, _) {
   }
   if (prim$3) {
     tmp.body = prim$3[0];
+  }
+  return tmp;
+}
+
+function sourceHtml(prim, prim$1, _) {
+  var tmp = { };
+  if (prim) {
+    tmp.html = prim[0];
+  }
+  if (prim$1) {
+    tmp.baseUrl = prim$1[0];
   }
   return tmp;
 }
@@ -147,7 +158,8 @@ function stopLoading(prim) {
   return /* () */0;
 }
 
-exports.source = source;
+exports.sourceUri = sourceUri;
+exports.sourceHtml = sourceHtml;
 exports.contentInsets = contentInsets;
 exports.goForward = goForward;
 exports.goBack = goBack;

--- a/lib/js/src/components/webView.js
+++ b/lib/js/src/components/webView.js
@@ -9,6 +9,23 @@ var ReactNative = require("react-native");
 var Props$BsReactNative = require("../private/props.js");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
+function source(prim, prim$1, prim$2, prim$3, _) {
+  var tmp = { };
+  if (prim) {
+    tmp.uri = prim[0];
+  }
+  if (prim$1) {
+    tmp.method = prim$1[0];
+  }
+  if (prim$2) {
+    tmp.headers = prim$2[0];
+  }
+  if (prim$3) {
+    tmp.body = prim$3[0];
+  }
+  return tmp;
+}
+
 function make(source, style, renderError, renderLoading, onError, onLoad, onLoadEnd, onLoadStart, automaticallyAdjustContentInsets, contentInsets, accessibilityLabel, accessible, hitSlop, onAccessibilityTap, onLayout, onMagicTap, responderHandlers, pointerEvents, removeClippedSubviews, testID, accessibilityComponentType, accessibilityLiveRegion, collapsable, importantForAccessibility, needsOffscreenAlphaCompositing, renderToHardwareTextureAndroid, accessibilityTraits, accessibilityViewIsModal, shouldRasterizeIOS, injectJavaScript, injectedJavaScript, mediaPlaybackRequiresUserAction, onMessage, onNavigationStateChange, scalesPageToFit, startInLoadingState, domStorageEnabled, javaScriptEnabled, mixedContentMode, thirdPartyCookiesEnabled, userAgent, allowsInlineMediaPlayback, bounces, dataDetectorTypes, decelerationRate, onShouldStartLoadWithRequest, scrollEnabled) {
   var partial_arg = Props$BsReactNative.extendView(accessibilityLabel, accessible, hitSlop, onAccessibilityTap, onLayout, onMagicTap, responderHandlers, pointerEvents, removeClippedSubviews, style, testID, accessibilityComponentType, accessibilityLiveRegion, collapsable, importantForAccessibility, needsOffscreenAlphaCompositing, renderToHardwareTextureAndroid, accessibilityTraits, accessibilityViewIsModal, shouldRasterizeIOS, {
         source: Js_undefined.fromOption(source),
@@ -160,6 +177,7 @@ function stopLoading(prim) {
 
 exports.sourceUri = sourceUri;
 exports.sourceHtml = sourceHtml;
+exports.source = source;
 exports.contentInsets = contentInsets;
 exports.goForward = goForward;
 exports.goBack = goBack;

--- a/src/components/webView.re
+++ b/src/components/webView.re
@@ -15,12 +15,22 @@ type iOSLoadRequestEvent = {
 type source;
 
 [@bs.obj]
-external source :
+external sourceUri :
   (
     ~uri: string=?,
     ~method: string=?,
     ~headers: Js.t('a)=?,
     ~body: string=?,
+    unit
+  ) =>
+  source =
+  "";
+
+[@bs.obj]
+external sourceHtml :
+  (
+    ~html: string=?,
+    ~baseUrl: string=?,
     unit
   ) =>
   source =

--- a/src/components/webView.re
+++ b/src/components/webView.re
@@ -36,6 +36,8 @@ external sourceHtml :
   source =
   "";
 
+let source = sourceUri;
+
 type contentInsets;
 
 [@bs.obj]

--- a/src/components/webView.rei
+++ b/src/components/webView.rei
@@ -6,6 +6,9 @@ let sourceUri:
 let sourceHtml:
 (~html: string=?, ~baseUrl: string=?, unit) => source;
 
+[@deprecated "Please use WebView.sourceUri instead"]
+let source: (~uri: string=?, ~method: string=?, ~headers: Js.t('a)=?, ~body: string=?, unit) => source;
+
 type iOSLoadRequestEvent = {
   .
   "target": int,

--- a/src/components/webView.rei
+++ b/src/components/webView.rei
@@ -1,7 +1,10 @@
 type source;
 
-let source:
+let sourceUri:
   (~uri: string=?, ~method: string=?, ~headers: Js.t('a)=?, ~body: string=?, unit) => source;
+
+let sourceHtml:
+(~html: string=?, ~baseUrl: string=?, unit) => source;
 
 type iOSLoadRequestEvent = {
   .


### PR DESCRIPTION
Renames `WebView.source` method to `WebView.sourceUri` and adds missing `WebView.sourceHtml`