### PR TITLE
Fix whileEditing to use kebab-case

### DIFF
--- a/src/components/textInput.re
+++ b/src/components/textInput.re
@@ -190,7 +190,7 @@ let make =
                   x =>
                     switch (x) {
                     | `never => "never"
-                    | `whileEditing => "whileEditing"
+                    | `whileEditing => "while-editing"
                     | `unlessEditing => "unless-editing"
                     | `always => "always"
                     },


### PR DESCRIPTION
`clearButtonMode` in TextInput uses kebab-case.
https://facebook.github.io/react-native/docs/textinput.html#clearbuttonmode