### PR TITLE
Adds Animated.FlatList

### DIFF
--- a/lib/js/src/animated.js
+++ b/lib/js/src/animated.js
@@ -49,6 +49,8 @@ var View = 0;
 
 var ScrollView = 0;
 
+var FlatList = 0;
+
 exports.Animation = Animation;
 exports.CompositeAnimation = CompositeAnimation;
 exports.Easing = Easing;
@@ -72,4 +74,5 @@ exports.Text = Text;
 exports.Image = Image;
 exports.View = View;
 exports.ScrollView = ScrollView;
+exports.FlatList = FlatList;
 /* AnimatedRe-BsReactNative Not a pure module */

--- a/lib/js/src/components/animatedComponents.js
+++ b/lib/js/src/components/animatedComponents.js
@@ -6,6 +6,7 @@ var ReactNative = require("react-native");
 var Text$BsReactNative = require("./text.js");
 var View$BsReactNative = require("./view.js");
 var Image$BsReactNative = require("./image.js");
+var FlatList$BsReactNative = require("./flatList.js");
 var AnimatedRe$BsReactNative = require("../animatedRe.js");
 var ScrollView$BsReactNative = require("./scrollView.js");
 
@@ -17,9 +18,13 @@ var view$1 = ReactNative.Animated.Image;
 
 var Image = Image$BsReactNative.CreateComponent(/* module */[/* view */view$1]);
 
-var view$2 = ReactNative.Animated.Text;
+var view$2 = AnimatedRe$BsReactNative.createAnimatedComponent(ReactNative.FlatList);
 
-var Text = Text$BsReactNative.CreateComponent(/* module */[/* view */view$2]);
+var FlatList = FlatList$BsReactNative.CreateComponent(/* module */[/* view */view$2]);
+
+var view$3 = ReactNative.Animated.Text;
+
+var Text = Text$BsReactNative.CreateComponent(/* module */[/* view */view$3]);
 
 function onScrollUpdater(x, y, $staropt$star, _) {
   var $$native = $staropt$star ? $staropt$star[0] : false;
@@ -35,9 +40,9 @@ function onScrollUpdater(x, y, $staropt$star, _) {
             });
 }
 
-var view$3 = ReactNative.Animated.ScrollView;
+var view$4 = ReactNative.Animated.ScrollView;
 
-var include = ScrollView$BsReactNative.CreateComponent(/* module */[/* view */view$3]);
+var include = ScrollView$BsReactNative.CreateComponent(/* module */[/* view */view$4]);
 
 var ScrollView_001 = /* scrollTo */include[0];
 
@@ -55,5 +60,6 @@ var ScrollView = /* module */[
 exports.View = View;
 exports.Image = Image;
 exports.Text = Text;
+exports.FlatList = FlatList;
 exports.ScrollView = ScrollView;
 /* View Not a pure module */

--- a/lib/js/src/components/flatList.js
+++ b/lib/js/src/components/flatList.js
@@ -8,6 +8,113 @@ var Js_undefined = require("bs-platform/lib/js/js_undefined.js");
 var ReactNative = require("react-native");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
+function CreateComponent(Impl) {
+  var scrollToEnd = function (ref, animated) {
+    ref.scrollToEnd({
+          animated: animated
+        });
+    return /* () */0;
+  };
+  var scrollToIndex = function (ref, index, animated, viewOffset, viewPosition, _) {
+    ref._scrollToIndex({
+          index: index,
+          viewOffset: Js_undefined.fromOption(viewOffset),
+          viewPosition: Js_undefined.fromOption(viewPosition),
+          animated: Js_undefined.fromOption(animated)
+        });
+    return /* () */0;
+  };
+  var scrollToItem = function (ref, item, animated, viewPosition, _) {
+    ref._scrollToIndex({
+          item: item,
+          viewPosition: Js_undefined.fromOption(viewPosition),
+          animated: Js_undefined.fromOption(animated)
+        });
+    return /* () */0;
+  };
+  var scrollToOffset = function (ref, offset, animated, _) {
+    ref._scrollToIndex({
+          offset: Js_undefined.fromOption(offset),
+          animated: Js_undefined.fromOption(animated)
+        });
+    return /* () */0;
+  };
+  var renderItem = function (reRenderItem, jsRenderBag) {
+    return Curry._1(reRenderItem, /* record */[
+                /* item */jsRenderBag.item,
+                /* index */jsRenderBag.index
+              ]);
+  };
+  var separatorComponent = function (reSeparatorComponent, jsSeparatorProps) {
+    return Curry._1(reSeparatorComponent, /* record */[
+                /* highlighted */jsSeparatorProps.highlighted,
+                /* leadingItem */Js_primitive.undefined_to_opt(jsSeparatorProps.leadingItem)
+              ]);
+  };
+  var make = function (data, renderItem, keyExtractor, itemSeparatorComponent, bounces, listFooterComponent, listHeaderComponent, columnWrapperStyle, extraData, getItemLayout, horizontal, initialNumToRender, initialScrollIndex, inverted, numColumns, onEndReached, onEndReachedThreshold, onRefresh, onViewableItemsChanged, overScrollMode, pagingEnabled, refreshing, removeClippedSubviews, scrollEnabled, showsHorizontalScrollIndicator, showsVerticalScrollIndicator, windowSize, maxToRenderPerBatch, viewabilityConfig, onScroll, style) {
+    var partial_arg = {
+      bounces: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(bounces)),
+      ItemSeparatorComponent: Js_undefined.fromOption(itemSeparatorComponent),
+      ListFooterComponent: Js_undefined.fromOption(listFooterComponent),
+      ListHeaderComponent: Js_undefined.fromOption(listHeaderComponent),
+      columnWrapperStyle: Js_undefined.fromOption(columnWrapperStyle),
+      data: data,
+      extraData: Js_undefined.fromOption(extraData),
+      getItemLayout: Js_undefined.fromOption(UtilsRN$BsReactNative.option_map((function (f, data, index) {
+                  return Curry._2(f, data === undefined ? /* None */0 : [data], index);
+                }), getItemLayout)),
+      horizontal: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(horizontal)),
+      initialNumToRender: Js_undefined.fromOption(initialNumToRender),
+      initialScrollIndex: Js_undefined.fromOption(initialScrollIndex),
+      inverted: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(inverted)),
+      keyExtractor: keyExtractor,
+      numColumns: Js_undefined.fromOption(numColumns),
+      onEndReached: Js_undefined.fromOption(onEndReached),
+      onEndReachedThreshold: Js_undefined.fromOption(onEndReachedThreshold),
+      onRefresh: Js_undefined.fromOption(onRefresh),
+      onViewableItemsChanged: Js_undefined.fromOption(onViewableItemsChanged),
+      overScrollMode: Js_undefined.fromOption(UtilsRN$BsReactNative.option_map((function (x) {
+                  if (x !== -958984497) {
+                    if (x >= 422592140) {
+                      return "never";
+                    } else {
+                      return "auto";
+                    }
+                  } else {
+                    return "always";
+                  }
+                }), overScrollMode)),
+      pagingEnabled: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(pagingEnabled)),
+      refreshing: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(refreshing)),
+      renderItem: renderItem,
+      removeClippedSubviews: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(removeClippedSubviews)),
+      scrollEnabled: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(scrollEnabled)),
+      showsHorizontalScrollIndicator: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsHorizontalScrollIndicator)),
+      showsVerticalScrollIndicator: Js_undefined.fromOption(UtilsRN$BsReactNative.optBoolToOptJsBoolean(showsVerticalScrollIndicator)),
+      windowSize: Js_undefined.fromOption(windowSize),
+      maxToRenderPerBatch: Js_undefined.fromOption(maxToRenderPerBatch),
+      viewabilityConfig: Js_undefined.fromOption(viewabilityConfig),
+      onScroll: Js_undefined.fromOption(onScroll),
+      style: Js_undefined.fromOption(style)
+    };
+    var partial_arg$1 = Impl[/* view */0];
+    return (function (param) {
+        return ReasonReact.wrapJsForReason(partial_arg$1, partial_arg, param);
+      });
+  };
+  return /* module */[
+          /* scrollToEnd */scrollToEnd,
+          /* scrollToIndex */scrollToIndex,
+          /* scrollToItem */scrollToItem,
+          /* scrollToOffset */scrollToOffset,
+          /* renderItem */renderItem,
+          /* separatorComponent */separatorComponent,
+          /* make */make
+        ];
+}
+
+var Impl = /* module */[/* FlatList */ReactNative.FlatList];
+
 function scrollToEnd(ref, animated) {
   ref.scrollToEnd({
         animated: animated
@@ -102,12 +209,13 @@ function make(data, renderItem, keyExtractor, itemSeparatorComponent, bounces, l
     onScroll: Js_undefined.fromOption(onScroll),
     style: Js_undefined.fromOption(style)
   };
-  var partial_arg$1 = ReactNative.FlatList;
+  var partial_arg$1 = Impl[/* view */0];
   return (function (param) {
       return ReasonReact.wrapJsForReason(partial_arg$1, partial_arg, param);
     });
 }
 
+exports.CreateComponent = CreateComponent;
 exports.scrollToEnd = scrollToEnd;
 exports.scrollToIndex = scrollToIndex;
 exports.scrollToItem = scrollToItem;
@@ -115,4 +223,4 @@ exports.scrollToOffset = scrollToOffset;
 exports.renderItem = renderItem;
 exports.separatorComponent = separatorComponent;
 exports.make = make;
-/* ReasonReact Not a pure module */
+/* Impl Not a pure module */

--- a/src/animated.re
+++ b/src/animated.re
@@ -7,3 +7,5 @@ module Image = AnimatedComponents.Image;
 module View = AnimatedComponents.View;
 
 module ScrollView = AnimatedComponents.ScrollView;
+
+module FlatList = AnimatedComponents.FlatList;

--- a/src/components/animatedComponents.re
+++ b/src/components/animatedComponents.re
@@ -1,29 +1,30 @@
 module View =
-  View.CreateComponent(
-    {
-      [@bs.module "react-native"] [@bs.scope "Animated"]
-      external view : ReasonReact.reactClass = "View";
-      let view = view;
-    },
-  );
+  View.CreateComponent({
+    [@bs.module "react-native"] [@bs.scope "Animated"]
+    external view : ReasonReact.reactClass = "View";
+    let view = view;
+  });
 
 module Image =
-  Image.CreateComponent(
-    {
-      [@bs.module "react-native"] [@bs.scope "Animated"]
-      external view : ReasonReact.reactClass = "Image";
-      let view = view;
-    },
-  );
+  Image.CreateComponent({
+    [@bs.module "react-native"] [@bs.scope "Animated"]
+    external view : ReasonReact.reactClass = "Image";
+    let view = view;
+  });
+
+module FlatList =
+  FlatList.CreateComponent({
+    [@bs.module "react-native"]
+    external nonAnimatedView : ReasonReact.reactClass = "FlatList";
+    let view = AnimatedRe.createAnimatedComponent(nonAnimatedView);
+  });
 
 module Text =
-  Text.CreateComponent(
-    {
-      [@bs.module "react-native"] [@bs.scope "Animated"]
-      external view : ReasonReact.reactClass = "Text";
-      let view = view;
-    },
-  );
+  Text.CreateComponent({
+    [@bs.module "react-native"] [@bs.scope "Animated"]
+    external view : ReasonReact.reactClass = "Text";
+    let view = view;
+  });
 
 module ScrollView = {
   type callback = RNEvent.NativeScrollEvent.t => unit;
@@ -45,12 +46,9 @@ module ScrollView = {
         {"useNativeDriver": native},
       ),
     );
-  include
-    ScrollView.CreateComponent(
-      {
-        [@bs.module "react-native"] [@bs.scope "Animated"]
-        external view : ReasonReact.reactClass = "ScrollView";
-        let view = view;
-      },
-    );
+  include ScrollView.CreateComponent({
+    [@bs.module "react-native"] [@bs.scope "Animated"]
+    external view : ReasonReact.reactClass = "ScrollView";
+    let view = view;
+  });
 };

--- a/src/components/animatedComponents.rei
+++ b/src/components/animatedComponents.rei
@@ -4,6 +4,8 @@ module Image: Image.ImageComponent;
 
 module Text: Text.TextComponent;
 
+module FlatList: FlatList.FlatListComponent;
+
 module ScrollView: {
   let onScrollUpdater:
     (~x: 'a=?, ~y: 'b=?, ~native: bool=?, unit, RNEvent.NativeScrollEvent.t) => unit;

--- a/src/components/flatList.re
+++ b/src/components/flatList.re
@@ -1,233 +1,364 @@
-[@bs.module "react-native"]
-external view : ReasonReact.reactClass = "FlatList";
+module type FlatListComponent = {
+  let scrollToEnd: (ReasonReact.reactRef, ~animated: bool) => unit;
 
-[@bs.send]
-external _scrollToEnd :
-  (ReasonReact.reactRef, {. "animated": bool}) => unit =
-  "scrollToEnd";
+  let scrollToIndex:
+    (
+      ReasonReact.reactRef,
+      ~index: int,
+      ~animated: bool=?,
+      ~viewOffset: int=?,
+      ~viewPosition: int=?,
+      unit
+    ) =>
+    unit;
 
-let scrollToEnd = (ref, ~animated) =>
-  _scrollToEnd(ref, {"animated": animated});
+  let scrollToItem:
+    (
+      ReasonReact.reactRef,
+      ~item: 'item,
+      ~animated: bool=?,
+      ~viewPosition: int=?,
+      unit
+    ) =>
+    unit;
 
-[@bs.send]
-external _scrollToIndex :
-  (
-    ReasonReact.reactRef,
-    {
-      .
-      "index": int,
-      "viewOffset": Js.undefined(int),
-      "viewPosition": Js.undefined(int),
-      "animated": Js.undefined(bool),
-    }
-  ) =>
-  unit =
-  "_scrollToIndex";
+  let scrollToOffset:
+    (ReasonReact.reactRef, ~offset: int=?, ~animated: bool=?, unit) => unit;
 
-let scrollToIndex =
-    (ref, ~index, ~animated=?, ~viewOffset=?, ~viewPosition=?, ()) =>
-  _scrollToIndex(
-    ref,
-    Js.Undefined.(
-      {
-        "index": index,
-        "viewOffset": fromOption(viewOffset),
-        "viewPosition": fromOption(viewPosition),
-        "animated": fromOption(animated),
-      }
-    ),
-  );
+  [@bs.send] external recordInteraction : ReasonReact.reactRef => unit = "";
 
-[@bs.send]
-external _scrollToItem :
-  (
-    ReasonReact.reactRef,
-    {
-      .
-      "item": 'item,
-      "viewPosition": Js.undefined(int),
-      "animated": Js.undefined(bool),
-    }
-  ) =>
-  unit =
-  "_scrollToIndex";
+  type renderBag('item) = {
+    item: 'item,
+    index: int,
+  };
 
-let scrollToItem = (ref, ~item, ~animated=?, ~viewPosition=?, ()) =>
-  _scrollToItem(
-    ref,
-    Js.Undefined.(
-      {
-        "item": item,
-        "viewPosition": fromOption(viewPosition),
-        "animated": fromOption(animated),
-      }
-    ),
-  );
+  type renderItem('item);
 
-[@bs.send]
-external _scrollToOffset :
-  (
-    ReasonReact.reactRef,
-    {
-      .
-      "offset": Js.undefined(int),
-      "animated": Js.undefined(bool),
-    }
-  ) =>
-  unit =
-  "_scrollToIndex";
+  let renderItem:
+    (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
 
-let scrollToOffset = (ref, ~offset=?, ~animated=?, ()) =>
-  _scrollToOffset(
-    ref,
-    Js.Undefined.(
-      {"offset": fromOption(offset), "animated": fromOption(animated)}
-    ),
-  );
+  type separatorComponent('item);
 
-[@bs.send] external recordInteraction : ReasonReact.reactRef => unit = "";
+  type separatorProps('item) = {
+    highlighted: bool,
+    leadingItem: option('item),
+  };
 
-type jsRenderBag('item) = {
-  .
-  "item": 'item,
-  "index": int,
-};
+  let separatorComponent:
+    (separatorProps('item) => ReasonReact.reactElement) =>
+    separatorComponent('item);
 
-type renderBag('item) = {
-  item: 'item,
-  index: int,
-};
-
-type renderItem('item) = jsRenderBag('item) => ReasonReact.reactElement;
-
-let renderItem =
-    (reRenderItem: renderBag('item) => ReasonReact.reactElement)
-    : renderItem('item) =>
-  (jsRenderBag: jsRenderBag('item)) =>
-    reRenderItem({item: jsRenderBag##item, index: jsRenderBag##index});
-
-type jsSeparatorProps('item) = {
-  .
-  "highlighted": bool,
-  "leadingItem": Js.Undefined.t('item),
-};
-
-type separatorProps('item) = {
-  highlighted: bool,
-  leadingItem: option('item),
-};
-
-type separatorComponent('item) =
-  jsSeparatorProps('item) => ReasonReact.reactElement;
-
-let separatorComponent =
-    (reSeparatorComponent: separatorProps('item) => ReasonReact.reactElement)
-    : separatorComponent('item) =>
-  (jsSeparatorProps: jsSeparatorProps('item)) =>
-    reSeparatorComponent({
-      highlighted: jsSeparatorProps##highlighted,
-      leadingItem: Js.Undefined.toOption(jsSeparatorProps##leadingItem),
-    });
-
-let make =
+  let make:
     (
       ~data: array('item),
       ~renderItem: renderItem('item),
       ~keyExtractor: ('item, int) => string,
-      ~itemSeparatorComponent: option(separatorComponent('item))=?,
-      ~bounces=?,
-      ~listFooterComponent=?,
-      ~listHeaderComponent=?,
-      ~columnWrapperStyle=?,
-      ~extraData=?,
-      ~getItemLayout=?,
-      ~horizontal=?,
-      ~initialNumToRender=?,
-      ~initialScrollIndex=?,
-      ~inverted=?,
-      ~numColumns=?,
-      ~onEndReached=?,
-      ~onEndReachedThreshold=?,
-      ~onRefresh=?,
-      ~onViewableItemsChanged=?,
-      ~overScrollMode=?,
-      ~pagingEnabled=?,
-      ~refreshing=?,
-      ~removeClippedSubviews=?,
-      ~scrollEnabled=?,
-      ~showsHorizontalScrollIndicator=?,
-      ~showsVerticalScrollIndicator=?,
-      ~windowSize=?,
-      ~maxToRenderPerBatch=?,
-      ~viewabilityConfig=?,
-      ~onScroll=?,
-      ~style=?,
+      ~itemSeparatorComponent: separatorComponent('item)=?,
+      ~bounces: bool=?,
+      ~listFooterComponent: ReasonReact.reactElement=?,
+      ~listHeaderComponent: ReasonReact.reactElement=?,
+      ~columnWrapperStyle: Style.t=?,
+      ~extraData: 'any=?,
+      ~getItemLayout: (option(array('item)), int) =>
+                      {
+                        .
+                        "length": int,
+                        "offset": int,
+                        "index": int,
+                      }
+                        =?,
+      ~horizontal: bool=?,
+      ~initialNumToRender: int=?,
+      ~initialScrollIndex: int=?,
+      ~inverted: bool=?,
+      ~numColumns: 'int=?,
+      ~onEndReached: {. "distanceFromEnd": float} => unit=?,
+      ~onEndReachedThreshold: float=?,
+      ~onRefresh: unit => unit=?,
+      ~onViewableItemsChanged: {
+                                 .
+                                 "viewableItems":
+                                   array(
+                                     {
+                                       .
+                                       "item": 'item,
+                                       "key": string,
+                                       "index": Js.undefined(int),
+                                       "isViewable": bool,
+                                       "section": Js.t({.}),
+                                     },
+                                   ),
+                                 "changed":
+                                   array(
+                                     {
+                                       .
+                                       "item": 'item,
+                                       "key": string,
+                                       "index": Js.undefined(int),
+                                       "isViewable": bool,
+                                       "section": Js.t({.}),
+                                     },
+                                   ),
+                               }
+                                 =?,
+      ~overScrollMode: [ | `auto | `always | `never]=?,
+      ~pagingEnabled: bool=?,
+      ~refreshing: bool=?,
+      ~removeClippedSubviews: bool=?,
+      ~scrollEnabled: bool=?,
+      ~showsHorizontalScrollIndicator: bool=?,
+      ~showsVerticalScrollIndicator: bool=?,
+      ~windowSize: int=?,
+      ~maxToRenderPerBatch: int=?,
+      ~viewabilityConfig: Js.t({.})=?,
+      ~onScroll: RNEvent.NativeScrollEvent.t => unit=?,
+      ~style: Style.t=?,
+      array(ReasonReact.reactElement)
     ) =>
-  ReasonReact.wrapJsForReason(
-    ~reactClass=view,
-    ~props=
+    ReasonReact.component(
+      ReasonReact.stateless,
+      ReasonReact.noRetainedProps,
+      unit,
+    );
+};
+
+module CreateComponent = (Impl: View.Impl) : FlatListComponent => {
+  [@bs.send]
+  external _scrollToEnd : (ReasonReact.reactRef, {. "animated": bool}) => unit =
+    "scrollToEnd";
+
+  let scrollToEnd = (ref, ~animated) =>
+    _scrollToEnd(ref, {"animated": animated});
+
+  [@bs.send]
+  external _scrollToIndex :
+    (
+      ReasonReact.reactRef,
+      {
+        .
+        "index": int,
+        "viewOffset": Js.undefined(int),
+        "viewPosition": Js.undefined(int),
+        "animated": Js.undefined(bool),
+      }
+    ) =>
+    unit =
+    "_scrollToIndex";
+
+  let scrollToIndex =
+      (ref, ~index, ~animated=?, ~viewOffset=?, ~viewPosition=?, ()) =>
+    _scrollToIndex(
+      ref,
       Js.Undefined.(
         {
-          "bounces": fromOption(UtilsRN.optBoolToOptJsBoolean(bounces)),
-          "ItemSeparatorComponent": fromOption(itemSeparatorComponent),
-          "ListFooterComponent": fromOption(listFooterComponent),
-          "ListHeaderComponent": fromOption(listHeaderComponent),
-          "columnWrapperStyle": fromOption(columnWrapperStyle),
-          "data": data,
-          "extraData": fromOption(extraData),
-          "getItemLayout":
-            fromOption(
-              UtilsRN.option_map(
-                (f, data, index) => f(Js.Undefined.toOption(data), index),
-                getItemLayout,
-              ),
-            ),
-          "horizontal":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(horizontal)),
-          "initialNumToRender": fromOption(initialNumToRender),
-          "initialScrollIndex": fromOption(initialScrollIndex),
-          "inverted":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(inverted)),
-          "keyExtractor": keyExtractor,
-          "numColumns": fromOption(numColumns),
-          "onEndReached": fromOption(onEndReached),
-          "onEndReachedThreshold": fromOption(onEndReachedThreshold),
-          "onRefresh": fromOption(onRefresh),
-          "onViewableItemsChanged": fromOption(onViewableItemsChanged),
-          "overScrollMode":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `auto => "auto"
-                  | `always => "always"
-                  | `never => "never"
-                  },
-                overScrollMode,
-              ),
-            ),
-          "pagingEnabled":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(pagingEnabled)),
-          "refreshing":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(refreshing)),
-          "renderItem": renderItem,
-          "removeClippedSubviews":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(removeClippedSubviews)),
-          "scrollEnabled":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(scrollEnabled)),
-          "showsHorizontalScrollIndicator":
-            fromOption(
-              UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
-            ),
-          "showsVerticalScrollIndicator":
-            fromOption(
-              UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
-            ),
-          "windowSize": fromOption(windowSize),
-          "maxToRenderPerBatch": fromOption(maxToRenderPerBatch),
-          "viewabilityConfig": fromOption(viewabilityConfig),
-          "onScroll": fromOption(onScroll),
-          "style": fromOption(style),
+          "index": index,
+          "viewOffset": fromOption(viewOffset),
+          "viewPosition": fromOption(viewPosition),
+          "animated": fromOption(animated),
         }
       ),
-  );
+    );
+
+  [@bs.send]
+  external _scrollToItem :
+    (
+      ReasonReact.reactRef,
+      {
+        .
+        "item": 'item,
+        "viewPosition": Js.undefined(int),
+        "animated": Js.undefined(bool),
+      }
+    ) =>
+    unit =
+    "_scrollToIndex";
+
+  let scrollToItem = (ref, ~item, ~animated=?, ~viewPosition=?, ()) =>
+    _scrollToItem(
+      ref,
+      Js.Undefined.(
+        {
+          "item": item,
+          "viewPosition": fromOption(viewPosition),
+          "animated": fromOption(animated),
+        }
+      ),
+    );
+
+  [@bs.send]
+  external _scrollToOffset :
+    (
+      ReasonReact.reactRef,
+      {
+        .
+        "offset": Js.undefined(int),
+        "animated": Js.undefined(bool),
+      }
+    ) =>
+    unit =
+    "_scrollToIndex";
+
+  let scrollToOffset = (ref, ~offset=?, ~animated=?, ()) =>
+    _scrollToOffset(
+      ref,
+      Js.Undefined.(
+        {"offset": fromOption(offset), "animated": fromOption(animated)}
+      ),
+    );
+
+  [@bs.send] external recordInteraction : ReasonReact.reactRef => unit = "";
+
+  type jsRenderBag('item) = {
+    .
+    "item": 'item,
+    "index": int,
+  };
+
+  type renderBag('item) = {
+    item: 'item,
+    index: int,
+  };
+
+  type renderItem('item) = jsRenderBag('item) => ReasonReact.reactElement;
+
+  let renderItem =
+      (reRenderItem: renderBag('item) => ReasonReact.reactElement)
+      : renderItem('item) =>
+    (jsRenderBag: jsRenderBag('item)) =>
+      reRenderItem({item: jsRenderBag##item, index: jsRenderBag##index});
+
+  type jsSeparatorProps('item) = {
+    .
+    "highlighted": bool,
+    "leadingItem": Js.Undefined.t('item),
+  };
+
+  type separatorProps('item) = {
+    highlighted: bool,
+    leadingItem: option('item),
+  };
+
+  type separatorComponent('item) =
+    jsSeparatorProps('item) => ReasonReact.reactElement;
+
+  let separatorComponent =
+      (
+        reSeparatorComponent:
+          separatorProps('item) => ReasonReact.reactElement,
+      )
+      : separatorComponent('item) =>
+    (jsSeparatorProps: jsSeparatorProps('item)) =>
+      reSeparatorComponent({
+        highlighted: jsSeparatorProps##highlighted,
+        leadingItem: Js.Undefined.toOption(jsSeparatorProps##leadingItem),
+      });
+
+  let make =
+      (
+        ~data: array('item),
+        ~renderItem: renderItem('item),
+        ~keyExtractor: ('item, int) => string,
+        ~itemSeparatorComponent: option(separatorComponent('item))=?,
+        ~bounces=?,
+        ~listFooterComponent=?,
+        ~listHeaderComponent=?,
+        ~columnWrapperStyle=?,
+        ~extraData=?,
+        ~getItemLayout=?,
+        ~horizontal=?,
+        ~initialNumToRender=?,
+        ~initialScrollIndex=?,
+        ~inverted=?,
+        ~numColumns=?,
+        ~onEndReached=?,
+        ~onEndReachedThreshold=?,
+        ~onRefresh=?,
+        ~onViewableItemsChanged=?,
+        ~overScrollMode=?,
+        ~pagingEnabled=?,
+        ~refreshing=?,
+        ~removeClippedSubviews=?,
+        ~scrollEnabled=?,
+        ~showsHorizontalScrollIndicator=?,
+        ~showsVerticalScrollIndicator=?,
+        ~windowSize=?,
+        ~maxToRenderPerBatch=?,
+        ~viewabilityConfig=?,
+        ~onScroll=?,
+        ~style=?,
+      ) =>
+    ReasonReact.wrapJsForReason(
+      ~reactClass=Impl.view,
+      ~props=
+        Js.Undefined.(
+          {
+            "bounces": fromOption(UtilsRN.optBoolToOptJsBoolean(bounces)),
+            "ItemSeparatorComponent": fromOption(itemSeparatorComponent),
+            "ListFooterComponent": fromOption(listFooterComponent),
+            "ListHeaderComponent": fromOption(listHeaderComponent),
+            "columnWrapperStyle": fromOption(columnWrapperStyle),
+            "data": data,
+            "extraData": fromOption(extraData),
+            "getItemLayout":
+              fromOption(
+                UtilsRN.option_map(
+                  (f, data, index) => f(Js.Undefined.toOption(data), index),
+                  getItemLayout,
+                ),
+              ),
+            "horizontal":
+              fromOption(UtilsRN.optBoolToOptJsBoolean(horizontal)),
+            "initialNumToRender": fromOption(initialNumToRender),
+            "initialScrollIndex": fromOption(initialScrollIndex),
+            "inverted": fromOption(UtilsRN.optBoolToOptJsBoolean(inverted)),
+            "keyExtractor": keyExtractor,
+            "numColumns": fromOption(numColumns),
+            "onEndReached": fromOption(onEndReached),
+            "onEndReachedThreshold": fromOption(onEndReachedThreshold),
+            "onRefresh": fromOption(onRefresh),
+            "onViewableItemsChanged": fromOption(onViewableItemsChanged),
+            "overScrollMode":
+              fromOption(
+                UtilsRN.option_map(
+                  x =>
+                    switch (x) {
+                    | `auto => "auto"
+                    | `always => "always"
+                    | `never => "never"
+                    },
+                  overScrollMode,
+                ),
+              ),
+            "pagingEnabled":
+              fromOption(UtilsRN.optBoolToOptJsBoolean(pagingEnabled)),
+            "refreshing":
+              fromOption(UtilsRN.optBoolToOptJsBoolean(refreshing)),
+            "renderItem": renderItem,
+            "removeClippedSubviews":
+              fromOption(
+                UtilsRN.optBoolToOptJsBoolean(removeClippedSubviews),
+              ),
+            "scrollEnabled":
+              fromOption(UtilsRN.optBoolToOptJsBoolean(scrollEnabled)),
+            "showsHorizontalScrollIndicator":
+              fromOption(
+                UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
+              ),
+            "showsVerticalScrollIndicator":
+              fromOption(
+                UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
+              ),
+            "windowSize": fromOption(windowSize),
+            "maxToRenderPerBatch": fromOption(maxToRenderPerBatch),
+            "viewabilityConfig": fromOption(viewabilityConfig),
+            "onScroll": fromOption(onScroll),
+            "style": fromOption(style),
+          }
+        ),
+    );
+};
+
+include CreateComponent({
+  [@bs.module "react-native"]
+  external view : ReasonReact.reactClass = "FlatList";
+});

--- a/src/components/flatList.rei
+++ b/src/components/flatList.rei
@@ -1,4 +1,6 @@
-let scrollToEnd: (ReasonReact.reactRef, ~animated: bool) => unit;
+module type FlatListComponent = {
+
+  let scrollToEnd: (ReasonReact.reactRef, ~animated: bool) => unit;
 
 let scrollToIndex:
   (
@@ -12,89 +14,115 @@ let scrollToIndex:
   unit;
 
 let scrollToItem:
-  (ReasonReact.reactRef, ~item: 'item, ~animated: bool=?, ~viewPosition: int=?, unit) => unit;
+  (
+    ReasonReact.reactRef,
+    ~item: 'item,
+    ~animated: bool=?,
+    ~viewPosition: int=?,
+    unit
+  ) =>
+  unit;
 
-let scrollToOffset: (ReasonReact.reactRef, ~offset: int=?, ~animated: bool=?, unit) => unit;
+let scrollToOffset:
+  (ReasonReact.reactRef, ~offset: int=?, ~animated: bool=?, unit) => unit;
 
 [@bs.send] external recordInteraction : ReasonReact.reactRef => unit = "";
 
-type renderBag('item) = {
-  item: 'item,
-  index: int
+  type renderBag('item) = {
+    item: 'item,
+    index: int,
+  };
+
+  type renderItem('item);
+
+  let renderItem:
+    (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
+
+  type separatorComponent('item);
+
+  type separatorProps('item) = {
+    highlighted: bool,
+    leadingItem: option('item),
+  };
+
+  let separatorComponent:
+    (separatorProps('item) => ReasonReact.reactElement) =>
+    separatorComponent('item);
+
+  let make:
+    (
+      ~data: array('item),
+      ~renderItem: renderItem('item),
+      ~keyExtractor: ('item, int) => string,
+      ~itemSeparatorComponent: separatorComponent('item)=?,
+      ~bounces: bool=?,
+      ~listFooterComponent: ReasonReact.reactElement=?,
+      ~listHeaderComponent: ReasonReact.reactElement=?,
+      ~columnWrapperStyle: Style.t=?,
+      ~extraData: 'any=?,
+      ~getItemLayout: (option(array('item)), int) =>
+                      {
+                        .
+                        "length": int,
+                        "offset": int,
+                        "index": int,
+                      }
+                        =?,
+      ~horizontal: bool=?,
+      ~initialNumToRender: int=?,
+      ~initialScrollIndex: int=?,
+      ~inverted: bool=?,
+      ~numColumns: 'int=?,
+      ~onEndReached: {. "distanceFromEnd": float} => unit=?,
+      ~onEndReachedThreshold: float=?,
+      ~onRefresh: unit => unit=?,
+      ~onViewableItemsChanged: {
+                                 .
+                                 "viewableItems":
+                                   array(
+                                     {
+                                       .
+                                       "item": 'item,
+                                       "key": string,
+                                       "index": Js.undefined(int),
+                                       "isViewable": bool,
+                                       "section": Js.t({.}),
+                                     },
+                                   ),
+                                 "changed":
+                                   array(
+                                     {
+                                       .
+                                       "item": 'item,
+                                       "key": string,
+                                       "index": Js.undefined(int),
+                                       "isViewable": bool,
+                                       "section": Js.t({.}),
+                                     },
+                                   ),
+                               }
+                                 =?,
+      ~overScrollMode: [ | `auto | `always | `never]=?,
+      ~pagingEnabled: bool=?,
+      ~refreshing: bool=?,
+      ~removeClippedSubviews: bool=?,
+      ~scrollEnabled: bool=?,
+      ~showsHorizontalScrollIndicator: bool=?,
+      ~showsVerticalScrollIndicator: bool=?,
+      ~windowSize: int=?,
+      ~maxToRenderPerBatch: int=?,
+      ~viewabilityConfig: Js.t({.})=?,
+      ~onScroll: RNEvent.NativeScrollEvent.t => unit=?,
+      ~style: Style.t=?,
+      array(ReasonReact.reactElement)
+    ) =>
+    ReasonReact.component(
+      ReasonReact.stateless,
+      ReasonReact.noRetainedProps,
+      unit,
+    );
 };
 
-type renderItem('item);
+module CreateComponent: (Impl: View.Impl) => FlatListComponent;
 
-let renderItem: (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
-
-type separatorComponent('item);
-
-type separatorProps('item) = {
-  highlighted: bool,
-  leadingItem: option('item)
-};
-
-let separatorComponent:
-  (separatorProps('item) => ReasonReact.reactElement) => separatorComponent('item);
-
-let make:
-  (
-    ~data: array('item),
-    ~renderItem: renderItem('item),
-    ~keyExtractor: ('item, int) => string,
-    ~itemSeparatorComponent: separatorComponent('item)=?,
-    ~bounces: bool=?,
-    ~listFooterComponent: ReasonReact.reactElement=?,
-    ~listHeaderComponent: ReasonReact.reactElement=?,
-    ~columnWrapperStyle: Style.t=?,
-    ~extraData: 'any=?,
-    ~getItemLayout: (option(array('item)), int) => {. "length": int, "offset": int, "index": int}=?,
-    ~horizontal: bool=?,
-    ~initialNumToRender: int=?,
-    ~initialScrollIndex: int=?,
-    ~inverted: bool=?,
-    ~numColumns: 'int=?,
-    ~onEndReached: {. "distanceFromEnd": float} => unit=?,
-    ~onEndReachedThreshold: float=?,
-    ~onRefresh: unit => unit=?,
-    ~onViewableItemsChanged: {
-                               .
-                               "viewableItems":
-                                 array(
-                                   {
-                                     .
-                                     "item": 'item,
-                                     "key": string,
-                                     "index": Js.undefined(int),
-                                     "isViewable": bool,
-                                     "section": Js.t({.})
-                                   }
-                                 ),
-                               "changed":
-                                 array(
-                                   {
-                                     .
-                                     "item": 'item,
-                                     "key": string,
-                                     "index": Js.undefined(int),
-                                     "isViewable": bool,
-                                     "section": Js.t({.})
-                                   }
-                                 )
-                             }
-                               =?,
-    ~overScrollMode: [ | `auto | `always | `never]=?,
-    ~pagingEnabled: bool=?,
-    ~refreshing: bool=?,
-    ~removeClippedSubviews: bool=?,
-    ~scrollEnabled: bool=?,
-    ~showsHorizontalScrollIndicator: bool=?,
-    ~showsVerticalScrollIndicator: bool=?,
-    ~windowSize: int=?,
-    ~maxToRenderPerBatch: int=?,
-    ~viewabilityConfig: Js.t({.})=?,
-    ~onScroll: RNEvent.NativeScrollEvent.t => unit=?,
-    ~style: Style.t=?,
-    array(ReasonReact.reactElement)
-  ) =>
-  ReasonReact.component(ReasonReact.stateless, ReasonReact.noRetainedProps, unit);
+include FlatListComponent;


### PR DESCRIPTION
- Adds `CreateComponent` functor to FlatList so that it can be used with both `FlatList` and `Animated.FlatList`
- Adds `FlatList` to `AnimatedComponents` module and to `Animated` module

FlatList has not yet been added to the Animated library in React-Native but I guess it will be added in the next release since this [commit](https://github.com/facebook/react-native/commit/daa7c78055857cd2d9ea650de0c4b0f72d3f2acf#diff-35653b5f6360716ec796e5ffdd483841) is already merged.

If you don't like having it in the `AnimatedComponents` module until it's released in React-Native I can remove it from there and only add the `CreateComponent` functor for `FlatList`