### PR TITLE
Fixes onmessage type

### DIFF
--- a/src/components/webView.rei
+++ b/src/components/webView.rei
@@ -106,7 +106,7 @@ let make:
     ~injectJavaScript: string => unit=?,
     ~injectedJavaScript: string=?,
     ~mediaPlaybackRequiresUserAction: bool=?,
-    ~onMessage: RNEvent.NativeEvent.t => unit=?,
+    ~onMessage: RNEvent.t => unit=?,
     ~onNavigationStateChange: EventTypes.t => unit=?,
     ~scalesPageToFit: bool=?,
     ~startInLoadingState: bool=?,


### PR DESCRIPTION
Was using OnMessage in a WebView and noticed it is wrongly typed. This fixes it.