### PR TITLE
Replace functions duplicating Bucklescript std lib

### DIFF
--- a/src/private/utilsRN.re
+++ b/src/private/utilsRN.re
@@ -15,48 +15,10 @@ external objAssign2 : (Js.t({..}), Js.t({..}), Js.t({..})) => Js.t({..}) =
 
 let (<<) = (f, g, x) => f(g(x));
 
-/***
- * The following is taken from bs-json (https://github.com/BuckleTypes/bs-json) converted to reason syntax
- */
-let dictEntries = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    let key = Array.unsafe_get(keys, i);
-    values[i] = (key, Js.Dict.unsafeGet(dict, key));
-  };
-  values;
-}; /* external values : 'a t -> 'a array = "Object.values" [@@bs.val] (* ES2017 *) */
+let dictEntries = Js.Dict.entries;
 
-let dictValues = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    values[i] = Js.Dict.unsafeGet(dict, Array.unsafe_get(keys, i));
-  };
-  values;
-};
+let dictValues = Js.Dict.values;
 
-let dictFromList = entries => {
-  let dict = Js.Dict.empty();
-  let rec loop =
-    fun
-    | [] => dict
-    | [(key, value), ...rest] => {
-        Js.Dict.set(dict, key, value);
-        loop(rest);
-      };
-  loop(entries);
-};
+let dictFromList = Js.Dict.fromList;
 
-let dictFromArray = entries => {
-  let dict = Js.Dict.empty();
-  let l = Js_array.length(entries);
-  for (i in 0 to l - 1) {
-    let (key, value) = Array.unsafe_get(entries, i);
-    Js.Dict.set(dict, key, value);
-  };
-  dict;
-};
+let dictFromArray = Js.Dict.fromArray;

--- a/src/style.re
+++ b/src/style.re
@@ -2,9 +2,6 @@ type t;
 
 type styleElement = (string, Js.Json.t);
 
-type pt_only =
-  | Pt(float);
-
 type pt_pct =
   | Pt(float)
   | Pct(float);
@@ -70,10 +67,10 @@ external array_to_style : array(t) => t = "%identity";
 let combine = (a, b) => {
   let entries =
     Array.append(
-      UtilsRN.dictEntries(style_to_dict(a)),
-      UtilsRN.dictEntries(style_to_dict(b)),
+      Js.Dict.entries(style_to_dict(a)),
+      Js.Dict.entries(style_to_dict(b)),
     );
-  UtilsRN.dictFromArray(entries) |> to_style;
+  Js.Dict.fromArray(entries) |> to_style;
 };
 
 let concat = styles => array_to_style(Array.of_list(styles));
@@ -86,7 +83,8 @@ let objectStyle = (key, value) => (key, Encode.object_(value));
 
 let arrayStyle = (key, value) => (key, Encode.array(value));
 
-let style = sarr => sarr |> UtilsRN.dictFromList |> to_style;
+let style = sarr => sarr |> Js.Dict.fromList |> to_style;
+
 
 /***
  * Layout Props
@@ -330,6 +328,7 @@ let direction = v =>
     },
   );
 
+
 /***
  * Shadow Props
  */
@@ -339,7 +338,7 @@ let shadowColor = value => (
 );
 
 let shadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])
@@ -385,7 +384,7 @@ module Transform = {
           switch (x) {
           | (key, Some(value)) =>
             let val_ =
-              UtilsRN.dictFromArray([|(key, value)|]) |> Encode.object_;
+              Js.Dict.fromArray([|(key, value)|]) |> Encode.object_;
             [val_, ...acc];
           | _ => acc
           },
@@ -486,6 +485,7 @@ module Transform = {
     );
 };
 
+
 /***
  * View Props
  */
@@ -563,6 +563,7 @@ let opacity = value => (
 );
 
 let elevation = floatStyle("elevation");
+
 
 /***
  * Text Props
@@ -651,7 +652,7 @@ let textShadowColor = value => (
 );
 
 let textShadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])
@@ -733,6 +734,7 @@ type resizeMode =
   | Repeat
   | Center;
 
+
 /*** Image props */
 let resizeMode = v =>
   stringStyle(
@@ -752,6 +754,3 @@ let overlayColor = value => (
   "overlayColor",
   encode_string_interpolated(value),
 );
-
-type color =
-  | String(string);

--- a/src/style.re
+++ b/src/style.re
@@ -2,6 +2,9 @@ type t;
 
 type styleElement = (string, Js.Json.t);
 
+type pt_only =
+  | Pt(float);
+
 type pt_pct =
   | Pt(float)
   | Pct(float);
@@ -328,7 +331,6 @@ let direction = v =>
     },
   );
 
-
 /***
  * Shadow Props
  */
@@ -484,7 +486,6 @@ module Transform = {
       skewY,
     );
 };
-
 
 /***
  * View Props
@@ -734,7 +735,6 @@ type resizeMode =
   | Repeat
   | Center;
 
-
 /*** Image props */
 let resizeMode = v =>
   stringStyle(
@@ -754,3 +754,6 @@ let overlayColor = value => (
   "overlayColor",
   encode_string_interpolated(value),
 );
+
+type color =
+  | String(string);


### PR DESCRIPTION
Redefined functions in `utilsRN.re` as aliases to functions in `Js.Dict` in case anybody wants to keep referencing them, and replaced the calls to them in `style.re.`