### PR TITLE
Replace functions duplicating Bucklescript std lib

### DIFF
--- a/src/private/props.re
+++ b/src/private/props.re
@@ -71,13 +71,12 @@ let extendView =
     Js.Undefined.(
       {
         "accessibilityLabel": fromOption(accessibilityLabel),
-        "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
+        "accessible": fromOption(accessible),
         "hitSlop": fromOption(hitSlop),
         "onAccessibilityTap": fromOption(onAccessibilityTap),
         "onLayout": fromOption(onLayout),
         "onMagicTap": fromOption(onMagicTap),
-        "removeClippedSubviews":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(removeClippedSubviews)),
+        "removeClippedSubviews": fromOption(removeClippedSubviews),
         "pointerEvents":
           fromOption(
             UtilsRN.option_map(
@@ -118,8 +117,7 @@ let extendView =
               accessibilityLiveRegion,
             ),
           ),
-        "collapsable":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(collapsable)),
+        "collapsable": fromOption(collapsable),
         "importantForAccessibility":
           fromOption(
             UtilsRN.option_map(
@@ -134,13 +132,9 @@ let extendView =
             ),
           ),
         "needsOffscreenAlphaCompositing":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(needsOffscreenAlphaCompositing),
-          ),
+          fromOption(needsOffscreenAlphaCompositing),
         "renderToHardwareTextureAndroid":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(renderToHardwareTextureAndroid),
-          ),
+          fromOption(renderToHardwareTextureAndroid),
         "accessibilityTraits":
           fromOption(
             UtilsRN.option_map(
@@ -170,11 +164,9 @@ let extendView =
             ),
           ),
         "accessibilityViewIsModal":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(accessibilityViewIsModal),
-          ),
+          fromOption(accessibilityViewIsModal),
         "shouldRasterizeIOS":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(shouldRasterizeIOS)),
+          fromOption(shouldRasterizeIOS)
       }
     ),
     moreProps,

--- a/src/private/utilsRN.re
+++ b/src/private/utilsRN.re
@@ -15,48 +15,10 @@ external objAssign2 : (Js.t({..}), Js.t({..}), Js.t({..})) => Js.t({..}) =
 
 let (<<) = (f, g, x) => f(g(x));
 
-/***
- * The following is taken from bs-json (https://github.com/BuckleTypes/bs-json) converted to reason syntax
- */
-let dictEntries = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    let key = Array.unsafe_get(keys, i);
-    values[i] = (key, Js.Dict.unsafeGet(dict, key));
-  };
-  values;
-}; /* external values : 'a t -> 'a array = "Object.values" [@@bs.val] (* ES2017 *) */
+let dictEntries = Js.Dict.entries;
 
-let dictValues = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    values[i] = Js.Dict.unsafeGet(dict, Array.unsafe_get(keys, i));
-  };
-  values;
-};
+let dictValues = Js.Dict.values;
 
-let dictFromList = entries => {
-  let dict = Js.Dict.empty();
-  let rec loop =
-    fun
-    | [] => dict
-    | [(key, value), ...rest] => {
-        Js.Dict.set(dict, key, value);
-        loop(rest);
-      };
-  loop(entries);
-};
+let dictFromList = Js.Dict.fromList;
 
-let dictFromArray = entries => {
-  let dict = Js.Dict.empty();
-  let l = Js_array.length(entries);
-  for (i in 0 to l - 1) {
-    let (key, value) = Array.unsafe_get(entries, i);
-    Js.Dict.set(dict, key, value);
-  };
-  dict;
-};
+let dictFromArray = Js.Dict.fromArray;

--- a/src/style.re
+++ b/src/style.re
@@ -70,10 +70,10 @@ external array_to_style : array(t) => t = "%identity";
 let combine = (a, b) => {
   let entries =
     Array.append(
-      UtilsRN.dictEntries(style_to_dict(a)),
-      UtilsRN.dictEntries(style_to_dict(b)),
+      Js.Dict.entries(style_to_dict(a)),
+      Js.Dict.entries(style_to_dict(b)),
     );
-  UtilsRN.dictFromArray(entries) |> to_style;
+  Js.Dict.fromArray(entries) |> to_style;
 };
 
 let concat = styles => array_to_style(Array.of_list(styles));
@@ -86,7 +86,8 @@ let objectStyle = (key, value) => (key, Encode.object_(value));
 
 let arrayStyle = (key, value) => (key, Encode.array(value));
 
-let style = sarr => sarr |> UtilsRN.dictFromList |> to_style;
+let style = sarr => sarr |> Js.Dict.fromList |> to_style;
+
 
 /***
  * Layout Props
@@ -339,7 +340,7 @@ let shadowColor = value => (
 );
 
 let shadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])
@@ -385,7 +386,7 @@ module Transform = {
           switch (x) {
           | (key, Some(value)) =>
             let val_ =
-              UtilsRN.dictFromArray([|(key, value)|]) |> Encode.object_;
+              Js.Dict.fromArray([|(key, value)|]) |> Encode.object_;
             [val_, ...acc];
           | _ => acc
           },
@@ -564,6 +565,7 @@ let opacity = value => (
 
 let elevation = floatStyle("elevation");
 
+
 /***
  * Text Props
  */
@@ -651,7 +653,7 @@ let textShadowColor = value => (
 );
 
 let textShadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])


### PR DESCRIPTION
Redefined functions in `utilsRN.re` as aliases to functions in `Js.Dict` in case anybody wants to keep referencing them, and replaced the calls to them in `style.re`.

I closed another pull request based on an earlier version of `style.re`.