### PR TITLE
Clean up bool conversions and calls to fromOption and functions duplicating BuckleScript std lib

### DIFF
--- a/src/alert.re
+++ b/src/alert.re
@@ -66,8 +66,7 @@ let alert = (~title, ~message=?, ~buttons=?, ~options=?, ~type_=?, ()) => {
     fromOption(
       UtilsRN.option_map(
         ({cancelable, onDismiss}) => {
-          "cancelable":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(cancelable)),
+          "cancelable": fromOption(cancelable),
           "onDismiss": fromOption(onDismiss),
         },
         options,

--- a/src/animatedRe.re
+++ b/src/animatedRe.re
@@ -53,8 +53,8 @@ module ValueAnimations = (Val: Value) => {
         makeConfig(
           ~velocity,
           ~deceleration?,
-          ~isInteraction=?UtilsRN.optBoolToOptJsBoolean(isInteraction),
-          ~useNativeDriver=?UtilsRN.optBoolToOptJsBoolean(useNativeDriver),
+          ~isInteraction?,
+          ~useNativeDriver?,
           ~onComplete?,
           ~iterations?,
         ),

--- a/src/components/activityIndicator.re
+++ b/src/components/activityIndicator.re
@@ -50,15 +50,12 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "animating": fromOption(UtilsRN.optBoolToOptJsBoolean(animating)),
-            "color": color,
-            "size": fromOption(UtilsRN.option_map(encodeSize, size)),
-            "hidesWhenStopped":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(hidesWhenStopped)),
-          }
-        ),
+        {
+          "animating": animating,
+          "color": color,
+          "size": UtilsRN.option_map(encodeSize, size),
+          "hidesWhenStopped": hidesWhenStopped,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/button.re
+++ b/src/components/button.re
@@ -13,14 +13,12 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=button,
     ~props=
-      Js.Undefined.(
-        {
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "color": fromOption(color),
-          "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-          "onPress": onPress,
-          "testID": fromOption(testID),
-          "title": title,
-        }
-      ),
+      {
+        "accessibilityLabel": accessibilityLabel,
+        "color": color,
+        "disabled": disabled,
+        "onPress": onPress,
+        "testID": testID,
+        "title": title,
+      },
   );

--- a/src/components/datePickerIOS.re
+++ b/src/components/datePickerIOS.re
@@ -42,17 +42,15 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "date": date,
-            "onDateChange": onDateChange,
-            "maximumDate": fromOption(maximumDate),
-            "minimumDate": fromOption(minimumDate),
-            "mode": fromOption(UtilsRN.option_map(encodeMode, mode)),
-            "minuteInterval": fromOption(minuteInterval),
-            "timeZoneOffsetInMinutes": fromOption(timeZoneOffsetInMinutes),
-          }
-        ),
+        {
+          "date": date,
+          "onDateChange": onDateChange,
+          "maximumDate": maximumDate,
+          "minimumDate": minimumDate,
+          "mode": UtilsRN.option_map(encodeMode, mode),
+          "minuteInterval": minuteInterval,
+          "timeZoneOffsetInMinutes": timeZoneOffsetInMinutes,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/flatList.re
+++ b/src/components/flatList.re
@@ -290,71 +290,52 @@ module CreateComponent = (Impl: View.Impl) : FlatListComponent => {
     ReasonReact.wrapJsForReason(
       ~reactClass=Impl.view,
       ~props=
-        Js.Undefined.(
-          {
-            "bounces": fromOption(UtilsRN.optBoolToOptJsBoolean(bounces)),
-            "ItemSeparatorComponent": fromOption(itemSeparatorComponent),
-            "ListFooterComponent": fromOption(listFooterComponent),
-            "ListHeaderComponent": fromOption(listHeaderComponent),
-            "columnWrapperStyle": fromOption(columnWrapperStyle),
-            "data": data,
-            "extraData": fromOption(extraData),
-            "getItemLayout":
-              fromOption(
-                UtilsRN.option_map(
-                  (f, data, index) => f(Js.Undefined.toOption(data), index),
-                  getItemLayout,
-                ),
-              ),
-            "horizontal":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(horizontal)),
-            "initialNumToRender": fromOption(initialNumToRender),
-            "initialScrollIndex": fromOption(initialScrollIndex),
-            "inverted": fromOption(UtilsRN.optBoolToOptJsBoolean(inverted)),
-            "keyExtractor": keyExtractor,
-            "numColumns": fromOption(numColumns),
-            "onEndReached": fromOption(onEndReached),
-            "onEndReachedThreshold": fromOption(onEndReachedThreshold),
-            "onRefresh": fromOption(onRefresh),
-            "onViewableItemsChanged": fromOption(onViewableItemsChanged),
-            "overScrollMode":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `auto => "auto"
-                    | `always => "always"
-                    | `never => "never"
-                    },
-                  overScrollMode,
-                ),
-              ),
-            "pagingEnabled":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(pagingEnabled)),
-            "refreshing":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(refreshing)),
-            "renderItem": renderItem,
-            "removeClippedSubviews":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(removeClippedSubviews),
-              ),
-            "scrollEnabled":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(scrollEnabled)),
-            "showsHorizontalScrollIndicator":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
-              ),
-            "showsVerticalScrollIndicator":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
-              ),
-            "windowSize": fromOption(windowSize),
-            "maxToRenderPerBatch": fromOption(maxToRenderPerBatch),
-            "viewabilityConfig": fromOption(viewabilityConfig),
-            "onScroll": fromOption(onScroll),
-            "style": fromOption(style),
-          }
-        ),
+        {
+          "bounces": bounces,
+          "ItemSeparatorComponent": itemSeparatorComponent,
+          "ListFooterComponent": listFooterComponent,
+          "ListHeaderComponent": listHeaderComponent,
+          "columnWrapperStyle": columnWrapperStyle,
+          "data": data,
+          "extraData": extraData,
+          "getItemLayout":
+            UtilsRN.option_map(
+              (f, data, index) => f(Js.Undefined.toOption(data), index),
+              getItemLayout,
+            ),
+          "horizontal": horizontal,
+          "initialNumToRender": initialNumToRender,
+          "initialScrollIndex": initialScrollIndex,
+          "inverted": inverted,
+          "keyExtractor": keyExtractor,
+          "numColumns": numColumns,
+          "onEndReached": onEndReached,
+          "onEndReachedThreshold": onEndReachedThreshold,
+          "onRefresh": onRefresh,
+          "onViewableItemsChanged": onViewableItemsChanged,
+          "overScrollMode":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `auto => "auto"
+                | `always => "always"
+                | `never => "never"
+                },
+              overScrollMode,
+            ),
+          "pagingEnabled": pagingEnabled,
+          "refreshing": refreshing,
+          "renderItem": renderItem,
+          "removeClippedSubviews": removeClippedSubviews,
+          "scrollEnabled": scrollEnabled,
+          "showsHorizontalScrollIndicator": showsHorizontalScrollIndicator,
+          "showsVerticalScrollIndicator": showsVerticalScrollIndicator,
+          "windowSize": windowSize,
+          "maxToRenderPerBatch": maxToRenderPerBatch,
+          "viewabilityConfig": viewabilityConfig,
+          "onScroll": onScroll,
+          "style": style,
+        },
     );
 };
 

--- a/src/components/image.re
+++ b/src/components/image.re
@@ -247,41 +247,32 @@ module CreateComponent = (Impl: View.Impl) : ImageComponent => {
     ReasonReact.wrapJsForReason(
       ~reactClass=Impl.view,
       ~props=
-        Js.Undefined.(
-          {
-            "onLayout": fromOption(onLayout),
-            "onError": fromOption(onError),
-            "onLoad": fromOption(onLoad),
-            "onLoadEnd": fromOption(onLoadEnd),
-            "onLoadStart": fromOption(onLoadStart),
-            "resizeMode":
-              fromOption(UtilsRN.option_map(encodeResizeMode, resizeMode)),
-            "source": encodeSource(source),
-            "style": fromOption(style),
-            "testID": fromOption(testID),
-            "resizeMethod":
-              fromOption(
-                UtilsRN.option_map(encodeResizeMethod, resizeMethod),
-              ),
-            "accessibilityLabel": fromOption(accessibilityLabel),
-            "accessible":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-            "blurRadius": fromOption(blurRadius),
-            "capInsets": fromOption(capInsets),
-            "defaultSource":
-              fromOption(
-                UtilsRN.option_map(encodeDefaultSource, defaultSource),
-              ),
-            "onPartialLoad": fromOption(onPartialLoad),
-            "onProgress":
-              fromOption(
-                UtilsRN.option_map(
-                  (x, y) => x(Event.progress(y)),
-                  onProgress,
-                ),
-              ),
-          }
-        ),
+        {
+          "onLayout": onLayout,
+          "onError": onError,
+          "onLoad": onLoad,
+          "onLoadEnd": onLoadEnd,
+          "onLoadStart": onLoadStart,
+          "resizeMode":
+            UtilsRN.option_map(encodeResizeMode, resizeMode),
+          "source": encodeSource(source),
+          "style": style,
+          "testID": testID,
+          "resizeMethod":
+            UtilsRN.option_map(encodeResizeMethod, resizeMethod),
+          "accessibilityLabel": accessibilityLabel,
+          "accessible": accessible,
+          "blurRadius": blurRadius,
+          "capInsets": capInsets,
+          "defaultSource":
+            UtilsRN.option_map(encodeDefaultSource, defaultSource),
+          "onPartialLoad": onPartialLoad,
+          "onProgress":
+            UtilsRN.option_map(
+              (x, y) => x(Event.progress(y)),
+              onProgress,
+            ),
+        },
     );
 };
 

--- a/src/components/imageBackground.re
+++ b/src/components/imageBackground.re
@@ -39,78 +39,65 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        {
-          "onLayout": fromOption(onLayout),
-          "onError": fromOption(onError),
-          "onLoad": fromOption(onLoad),
-          "onLoadEnd": fromOption(onLoadEnd),
-          "onLoadStart": fromOption(onLoadStart),
-          "resizeMode":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `cover => "cover"
-                  | `contain => "contain"
-                  | `stretch => "stretch"
-                  | `repeat => "repeat"
-                  | `center => "center"
-                  },
-                resizeMode,
-              ),
-            ),
-          "source":
-            fromOption(
-              UtilsRN.option_map(
-                (x: Image.imageSource) =>
-                  switch (x) {
-                  | `URI(x) => rawImageSourceJS(x)
-                  | `Required(x) => rawImageSourceJS(x)
-                  | `Multiple(x) => rawImageSourceJS(Array.of_list(x))
-                  },
-                source,
-              ),
-            ),
-          "style": fromOption(style),
-          "imageStyle": fromOption(imageStyle),
-          "testID": fromOption(testID),
-          "resizeMethod":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `auto => "auto"
-                  | `resize => "resize"
-                  | `scale => "scale"
-                  },
-                resizeMethod,
-              ),
-            ),
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "accessible":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-          "blurRadius": fromOption(blurRadius),
-          "capInsets": fromOption(capInsets),
-          "defaultSource":
-            fromOption(
-              UtilsRN.option_map(
-                (x: Image.defaultSource) =>
-                  switch (x) {
-                  | `URI(x) => rawImageSourceJS(x)
-                  | `Required(x) => rawImageSourceJS(x)
-                  },
-                defaultSource,
-              ),
-            ),
-          "onPartialLoad": fromOption(onPartialLoad),
-          "onProgress":
-            fromOption(
-              UtilsRN.option_map(
-                (x, y) => x(Event.progress(y)),
-                onProgress,
-              ),
-            ),
-        }
-      ),
+      {
+        "onLayout": onLayout,
+        "onError": onError,
+        "onLoad": onLoad,
+        "onLoadEnd": onLoadEnd,
+        "onLoadStart": onLoadStart,
+        "resizeMode":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `cover => "cover"
+              | `contain => "contain"
+              | `stretch => "stretch"
+              | `repeat => "repeat"
+              | `center => "center"
+              },
+            resizeMode,
+          ),
+        "source":
+          UtilsRN.option_map(
+            (x: Image.imageSource) =>
+              switch (x) {
+              | `URI(x) => rawImageSourceJS(x)
+              | `Required(x) => rawImageSourceJS(x)
+              | `Multiple(x) => rawImageSourceJS(Array.of_list(x))
+              },
+            source,
+          ),
+        "style": style,
+        "imageStyle": imageStyle,
+        "testID": testID,
+        "resizeMethod":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `auto => "auto"
+              | `resize => "resize"
+              | `scale => "scale"
+              },
+            resizeMethod,
+          ),
+        "accessibilityLabel": accessibilityLabel,
+        "accessible": accessible,
+        "blurRadius": blurRadius,
+        "capInsets": capInsets,
+        "defaultSource":
+          UtilsRN.option_map(
+            (x: Image.defaultSource) =>
+              switch (x) {
+              | `URI(x) => rawImageSourceJS(x)
+              | `Required(x) => rawImageSourceJS(x)
+              },
+            defaultSource,
+          ),
+        "onPartialLoad": onPartialLoad,
+        "onProgress":
+          UtilsRN.option_map(
+            (x, y) => x(Event.progress(y)),
+            onProgress,
+          ),
+      },
   );

--- a/src/components/keyboardAvoidingView.re
+++ b/src/components/keyboardAvoidingView.re
@@ -34,34 +34,32 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=keyboardAvoidingView,
     ~props=
-      Js.Undefined.(
-        Props.extendView(
-          ~accessibilityLabel?,
-          ~accessible?,
-          ~hitSlop?,
-          ~onAccessibilityTap?,
-          ~onLayout?,
-          ~onMagicTap?,
-          ~responderHandlers?,
-          ~pointerEvents?,
-          ~removeClippedSubviews?,
-          ~style?,
-          ~testID?,
-          ~accessibilityComponentType?,
-          ~accessibilityLiveRegion?,
-          ~collapsable?,
-          ~importantForAccessibility?,
-          ~needsOffscreenAlphaCompositing?,
-          ~renderToHardwareTextureAndroid?,
-          ~accessibilityTraits?,
-          ~accessibilityViewIsModal?,
-          ~shouldRasterizeIOS?,
-          {
-            "keyboardVerticalOffset": fromOption(keyboardVerticalOffset),
-            "behavior":
-              fromOption(UtilsRN.option_map(behaviorToJs, behavior)),
-            "contentContainerStyle": fromOption(contentContainerStyle),
-          },
-        )
-      ),
+      Props.extendView(
+        ~accessibilityLabel?,
+        ~accessible?,
+        ~hitSlop?,
+        ~onAccessibilityTap?,
+        ~onLayout?,
+        ~onMagicTap?,
+        ~responderHandlers?,
+        ~pointerEvents?,
+        ~removeClippedSubviews?,
+        ~style?,
+        ~testID?,
+        ~accessibilityComponentType?,
+        ~accessibilityLiveRegion?,
+        ~collapsable?,
+        ~importantForAccessibility?,
+        ~needsOffscreenAlphaCompositing?,
+        ~renderToHardwareTextureAndroid?,
+        ~accessibilityTraits?,
+        ~accessibilityViewIsModal?,
+        ~shouldRasterizeIOS?,
+        {
+          "keyboardVerticalOffset": keyboardVerticalOffset,
+          "behavior":
+            UtilsRN.option_map(behaviorToJs, behavior),
+          "contentContainerStyle": contentContainerStyle,
+        },
+      )
   );

--- a/src/components/modal.re
+++ b/src/components/modal.re
@@ -34,27 +34,19 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=modal,
     ~props=
-      Js.Undefined.(
-        {
-          "animationType":
-            fromOption(
-              UtilsRN.option_map(encodeAnimationType, animationType),
-            ),
-          "onShow": fromOption(onShow),
-          "transparent":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(transparent)),
-          "visible": fromOption(UtilsRN.optBoolToOptJsBoolean(visible)),
-          "hardwareAccelerated":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(hardwareAccelerated)),
-          "onRequestClose": fromOption(onRequestClose),
-          "onOrientationChange": fromOption(onOrientationChange),
-          "supportedOrientations":
-            fromOption(
-              UtilsRN.option_map(
-                encodeSupportedOrientations,
-                supportedOrientations,
-              ),
-            ),
-        }
-      ),
+      {
+        "animationType":
+          UtilsRN.option_map(encodeAnimationType, animationType),
+        "onShow": onShow,
+        "transparent": transparent,
+        "visible": visible,
+        "hardwareAccelerated": hardwareAccelerated,
+        "onRequestClose": onRequestClose,
+        "onOrientationChange": onOrientationChange,
+        "supportedOrientations":
+          UtilsRN.option_map(
+            encodeSupportedOrientations,
+            supportedOrientations,
+          ),
+      },
   );

--- a/src/components/picker.re
+++ b/src/components/picker.re
@@ -7,14 +7,12 @@ module Item = {
     ReasonReact.wrapJsForReason(
       ~reactClass=item,
       ~props=
-        Js.Undefined.(
-          {
-            "label": label,
-            "value": fromOption(value),
-            "color": fromOption(color),
-            "testID": fromOption(testID),
-          }
-        ),
+        {
+          "label": label,
+          "value": value,
+          "color": color,
+          "testID": testID,
+        },
     );
 };
 
@@ -58,16 +56,14 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "enabled": fromOption(UtilsRN.optBoolToOptJsBoolean(enabled)),
-            "onValueChange": fromOption(onValueChange),
-            "selectedValue": fromOption(selectedValue),
-            "itemStyle": fromOption(itemStyle),
-            "prompt": fromOption(prompt),
-            "mode": fromOption(UtilsRN.option_map(encodeMode, mode)),
-          }
-        ),
+        {
+          "enabled": enabled,
+          "onValueChange": onValueChange,
+          "selectedValue": selectedValue,
+          "itemStyle": itemStyle,
+          "prompt": prompt,
+          "mode": UtilsRN.option_map(encodeMode, mode),
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/pickerIOS.re
+++ b/src/components/pickerIOS.re
@@ -8,13 +8,11 @@ module Item = {
     ReasonReact.wrapJsForReason(
       ~reactClass=item,
       ~props=
-        Js.Undefined.(
-          {
-            "label": label,
-            "value": fromOption(value),
-            "color": fromOption(color),
-          }
-        ),
+        {
+          "label": label,
+          "value": value,
+          "color": color,
+        },
     );
 };
 
@@ -49,13 +47,11 @@ let make =
     ~reactClass=pickerIOS,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "itemStyle": fromOption(itemStyle),
-            "onValueChange": fromOption(onValueChange),
-            "selectedValue": fromOption(selectedValue),
-          }
-        ),
+        {
+          "itemStyle": itemStyle,
+          "onValueChange": onValueChange,
+          "selectedValue": selectedValue,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/progressBarAndroid.re
+++ b/src/components/progressBarAndroid.re
@@ -45,17 +45,15 @@ let make =
     ~reactClass=component,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "animating": fromOption(animating),
-            "color": fromOption(color),
-            "indeterminate": fromOption(indeterminate),
-            "progress": fromOption(progress),
-            "styleAttr":
-              fromOption(UtilsRN.option_map(styleAttribute, styleAttr)),
-            "testID": fromOption(testID),
-          }
-        ),
+        {
+          "animating": animating,
+          "color": color,
+          "indeterminate": indeterminate,
+          "progress": progress,
+          "styleAttr":
+            UtilsRN.option_map(styleAttribute, styleAttr),
+          "testID": testID,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/progressViewIOS.re
+++ b/src/components/progressViewIOS.re
@@ -35,16 +35,14 @@ let make =
     ~reactClass=progressViewIOS,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "progress": progress,
-            "progressImage": fromOption(progressImage),
-            "progressTintColor": fromOption(progressTintColor),
-            "progressViewStyle": fromOption(progressViewStyle),
-            "trackImage": fromOption(trackImage),
-            "trackTintColor": fromOption(trackTintColor),
-          }
-        ),
+        {
+          "progress": progress,
+          "progressImage": progressImage,
+          "progressTintColor": progressTintColor,
+          "progressViewStyle": progressViewStyle,
+          "trackImage": trackImage,
+          "trackTintColor": trackTintColor,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/refreshControl.re
+++ b/src/components/refreshControl.re
@@ -37,20 +37,17 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "onRefresh": fromOption(onRefresh),
-            "refreshing":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(refreshing)),
-            "colors": fromOption(colors),
-            "enabled": fromOption(UtilsRN.optBoolToOptJsBoolean(enabled)),
-            "progressBackgroundColor": fromOption(progressBackgroundColor),
-            "progressViewOffset": fromOption(progressViewOffset),
-            "tintColor": fromOption(tintColor),
-            "title": fromOption(title),
-            "titleColor": fromOption(titleColor),
-          }
-        ),
+        {
+          "onRefresh": onRefresh,
+          "refreshing": refreshing,
+          "colors": colors,
+          "enabled": enabled,
+          "progressBackgroundColor": progressBackgroundColor,
+          "progressViewOffset": progressViewOffset,
+          "tintColor": tintColor,
+          "title": title,
+          "titleColor": titleColor,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/scrollView.re
+++ b/src/components/scrollView.re
@@ -183,147 +183,99 @@ module CreateComponent = (Impl: View.Impl) : ScrollViewComponent => {
       ~reactClass=Impl.view,
       ~props=
         Props.extendView(
-          Js.Undefined.(
-            {
-              "contentContainerStyle": fromOption(contentContainerStyle),
-              "horizontal":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(horizontal)),
-              "keyboardDismissMode":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `interactive => "interactive"
-                      | `none => "none"
-                      | `onDrag => "on-drag"
-                      },
-                    keyboardDismissMode,
-                  ),
-                ),
-              "keyboardShouldPersistTaps":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `always => "always"
-                      | `never => "never"
-                      | `handled => "handled"
-                      },
-                    keyboardShouldPersistTaps,
-                  ),
-                ),
-              "onContentSizeChange": fromOption(onContentSizeChange),
-              "onScroll": fromOption(onScroll),
-              "pagingEnabled":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(pagingEnabled)),
-              "refreshControl": fromOption(refreshControl),
-              "scrollEnabled":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(scrollEnabled)),
-              "showsHorizontalScrollIndicator":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(
-                    showsHorizontalScrollIndicator,
-                  ),
-                ),
-              "showsVerticalScrollIndicator":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
-                ),
-              "stickyHeaderIndices":
-                fromOption(
-                  UtilsRN.option_map(Array.of_list, stickyHeaderIndices),
-                ),
-              "overScrollMode":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `always => "always"
-                      | `never => "never"
-                      | `auto => "auto"
-                      },
-                    overScrollMode,
-                  ),
-                ),
-              "scrollPerfTag": fromOption(scrollPerfTag),
-              "alwaysBounceHorizontal":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(alwaysBounceHorizontal),
-                ),
-              "alwaysBounceVertical":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(alwaysBounceVertical),
-                ),
-              "automaticallyAdjustContentInsets":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(
-                    automaticallyAdjustContentInsets,
-                  ),
-                ),
-              "bounces": fromOption(UtilsRN.optBoolToOptJsBoolean(bounces)),
-              "canCancelContentTouches":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(canCancelContentTouches),
-                ),
-              "centerContent":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(centerContent)),
-              "contentInset": fromOption(contentInset),
-              "contentOffset":
-                fromOption(
-                  UtilsRN.option_map(
-                    ({x, y}) => {"x": x, "y": y},
-                    contentOffset,
-                  ),
-                ),
-              "decelerationRate":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `fast => "fast"
-                      | `normal => "normal"
-                      },
-                    decelerationRate,
-                  ),
-                ),
-              "directionalLockEnabled":
-                fromOption(
-                  UtilsRN.optBoolToOptJsBoolean(directionalLockEnabled),
-                ),
-              "indicatorStyle":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `default => "default"
-                      | `black => "black"
-                      | `white => "white"
-                      },
-                    indicatorStyle,
-                  ),
-                ),
-              "maximumZoomScale": fromOption(maximumZoomScale),
-              "minimumZoomScale": fromOption(minimumZoomScale),
-              "onScrollAnimationEnd": fromOption(onScrollAnimationEnd),
-              "scrollEventThrottle": fromOption(scrollEventThrottle),
-              "scrollIndicatorInsets": fromOption(scrollIndicatorInsets),
-              "scrollsToTop":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(scrollsToTop)),
-              "snapToAlignment":
-                fromOption(
-                  UtilsRN.option_map(
-                    x =>
-                      switch (x) {
-                      | `center => "center"
-                      | `start => "start"
-                      | `end_ => "end"
-                      },
-                    snapToAlignment,
-                  ),
-                ),
-              "zoomScale": fromOption(zoomScale),
-            }
-          ),
+          {
+            "contentContainerStyle": contentContainerStyle,
+            "horizontal": horizontal,
+            "keyboardDismissMode":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `interactive => "interactive"
+                  | `none => "none"
+                  | `onDrag => "on-drag"
+                  },
+                keyboardDismissMode,
+              ),
+            "keyboardShouldPersistTaps":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `always => "always"
+                  | `never => "never"
+                  | `handled => "handled"
+                  },
+                keyboardShouldPersistTaps,
+              ),
+            "onContentSizeChange": onContentSizeChange,
+            "onScroll": onScroll,
+            "pagingEnabled": pagingEnabled,
+            "refreshControl": refreshControl,
+            "scrollEnabled": scrollEnabled,
+            "showsHorizontalScrollIndicator": showsHorizontalScrollIndicator,
+            "showsVerticalScrollIndicator": showsVerticalScrollIndicator,
+            "stickyHeaderIndices":
+              UtilsRN.option_map(Array.of_list, stickyHeaderIndices),
+            "overScrollMode":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `always => "always"
+                  | `never => "never"
+                  | `auto => "auto"
+                  },
+                overScrollMode,
+              ),
+            "scrollPerfTag": scrollPerfTag,
+            "alwaysBounceHorizontal": alwaysBounceHorizontal,
+            "alwaysBounceVertical": alwaysBounceVertical,
+            "automaticallyAdjustContentInsets": automaticallyAdjustContentInsets,
+            "bounces": bounces,
+            "canCancelContentTouches": canCancelContentTouches,
+            "centerContent": centerContent,
+            "contentInset": contentInset,
+            "contentOffset":
+              UtilsRN.option_map(
+                ({x, y}) => {"x": x, "y": y},
+                contentOffset,
+              ),
+            "decelerationRate":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `fast => "fast"
+                  | `normal => "normal"
+                  },
+                decelerationRate,
+              ),
+            "directionalLockEnabled": directionalLockEnabled,
+            "indicatorStyle":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `default => "default"
+                  | `black => "black"
+                  | `white => "white"
+                  },
+                indicatorStyle,
+              ),
+            "maximumZoomScale": maximumZoomScale,
+            "minimumZoomScale": minimumZoomScale,
+            "onScrollAnimationEnd": onScrollAnimationEnd,
+            "scrollEventThrottle": scrollEventThrottle,
+            "scrollIndicatorInsets": scrollIndicatorInsets,
+            "scrollsToTop": scrollsToTop,
+            "snapToAlignment":
+              UtilsRN.option_map(
+                x =>
+                  switch (x) {
+                  | `center => "center"
+                  | `start => "start"
+                  | `end_ => "end"
+                  },
+                snapToAlignment,
+              ),
+            "zoomScale": zoomScale,
+          },
           ~accessibilityLabel?,
           ~accessible?,
           ~hitSlop?,

--- a/src/components/sectionList.re
+++ b/src/components/sectionList.re
@@ -217,58 +217,39 @@ let make:
     ReasonReact.wrapJsForReason(
       ~reactClass=view,
       ~props=
-        Js.Undefined.(
-          {
-            "sections": sections,
-            "renderItem": renderItem,
-            "keyExtractor": keyExtractor,
-            "ItemSeparatorComponent": fromOption(itemSeparatorComponent),
-            "ListEmptyComponent": fromOption(listEmptyComponent),
-            "ListFooterComponent": fromOption(listFooterComponent),
-            "ListHeaderComponent": fromOption(listHeaderComponent),
-            "SectionSeparatorComponent":
-              fromOption(sectionSeparatorComponent),
-            "inverted": fromOption(UtilsRN.optBoolToOptJsBoolean(inverted)),
-            "extraData": fromOption(extraData),
-            "initialNumToRender": fromOption(initialNumToRender),
-            "onEndReached": fromOption(onEndReached),
-            "onEndReachedThreshold": fromOption(onEndReachedThreshold),
-            "onRefresh": fromOption(onRefresh),
-            "onViewableItemsChanged": fromOption(onViewableItemsChanged),
-            "refreshing":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(refreshing)),
-            "renderSectionHeader": fromOption(renderSectionHeader),
-            "renderSectionFooter": fromOption(renderSectionFooter),
-            "stickySectionHeadersEnabled":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(stickySectionHeadersEnabled),
-              ),
-            "keyboardDismissMode":
-              fromOption(
-                keyboardDismissMode
-                |> UtilsRN.option_map(keyboardDismissModeToJs),
-              ),
-            "keyboardShouldPersistTaps":
-              fromOption(
-                keyboardShouldPersistTaps
-                |> UtilsRN.option_map(keyboardShouldPersistTapsToJs),
-              ),
-            "showsHorizontalScrollIndicator":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(showsHorizontalScrollIndicator),
-              ),
-            "showsVerticalScrollIndicator":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(showsVerticalScrollIndicator),
-              ),
-            "getItemLayout":
-              fromOption(
-                UtilsRN.option_map(
-                  (f, data, index) => f(Js.Undefined.toOption(data), index),
-                  getItemLayout,
-                ),
-              ),
-          }
-        ),
+        {
+          "sections": sections,
+          "renderItem": renderItem,
+          "keyExtractor": keyExtractor,
+          "ItemSeparatorComponent": itemSeparatorComponent,
+          "ListEmptyComponent": listEmptyComponent,
+          "ListFooterComponent": listFooterComponent,
+          "ListHeaderComponent": listHeaderComponent,
+          "SectionSeparatorComponent": sectionSeparatorComponent,
+          "inverted": inverted,
+          "extraData": extraData,
+          "initialNumToRender": initialNumToRender,
+          "onEndReached": onEndReached,
+          "onEndReachedThreshold": onEndReachedThreshold,
+          "onRefresh": onRefresh,
+          "onViewableItemsChanged": onViewableItemsChanged,
+          "refreshing": refreshing,
+          "renderSectionHeader": renderSectionHeader,
+          "renderSectionFooter": renderSectionFooter,
+          "stickySectionHeadersEnabled": stickySectionHeadersEnabled,
+          "keyboardDismissMode":
+            keyboardDismissMode
+            |> UtilsRN.option_map(keyboardDismissModeToJs),
+          "keyboardShouldPersistTaps":
+            keyboardShouldPersistTaps
+            |> UtilsRN.option_map(keyboardShouldPersistTapsToJs),
+          "showsHorizontalScrollIndicator": showsHorizontalScrollIndicator,
+          "showsVerticalScrollIndicator": showsVerticalScrollIndicator,
+          "getItemLayout":
+            UtilsRN.option_map(
+              (f, data, index) => f(Js.Undefined.toOption(data), index),
+              getItemLayout,
+            ),
+        },
       _children,
     );

--- a/src/components/segmentedControllOS.re
+++ b/src/components/segmentedControllOS.re
@@ -35,18 +35,15 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "enabled": fromOption @@ UtilsRN.optBoolToOptJsBoolean(enabled),
-            "momentary":
-              fromOption @@ UtilsRN.optBoolToOptJsBoolean(momentary),
-            "tintColor": fromOption(tintColor),
-            "values": Array.of_list(values),
-            "selectedIndex": fromOption(selectedIndex),
-            "onChange": fromOption(onChange),
-            "onValueChange": fromOption(onValueChange),
-          }
-        ),
+        {
+          "enabled": enabled,
+          "momentary": momentary,
+          "tintColor": tintColor,
+          "values": Array.of_list(values),
+          "selectedIndex": selectedIndex,
+          "onChange": onChange,
+          "onValueChange": onValueChange,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/slider.re
+++ b/src/components/slider.re
@@ -52,32 +52,26 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-            "maximumTrackTintColor": fromOption(maximumTrackTintColor),
-            "maximumValue": fromOption(maximumValue),
-            "minimumTrackTintColor": fromOption(minimumTrackTintColor),
-            "minimumValue": fromOption(minimumValue),
-            "onSlidingComplete": fromOption(onSlidingComplete),
-            "onValueChange": fromOption(onValueChange),
-            "step": fromOption(step),
-            "value": fromOption(value),
-            "thumbTintColor": fromOption(thumbTintColor),
-            "maximumTrackImage":
-              fromOption(
-                UtilsRN.option_map(convertImageSource, maximumTrackImage),
-              ),
-            "minimumTrackImage":
-              fromOption(
-                UtilsRN.option_map(convertImageSource, minimumTrackImage),
-              ),
-            "thumbImage":
-              fromOption(UtilsRN.option_map(convertImageSource, thumbImage)),
-            "trackImage":
-              fromOption(UtilsRN.option_map(convertImageSource, trackImage)),
-          }
-        ),
+        {
+          "disabled": disabled,
+          "maximumTrackTintColor": maximumTrackTintColor,
+          "maximumValue": maximumValue,
+          "minimumTrackTintColor": minimumTrackTintColor,
+          "minimumValue": minimumValue,
+          "onSlidingComplete": onSlidingComplete,
+          "onValueChange": onValueChange,
+          "step": step,
+          "value": value,
+          "thumbTintColor": thumbTintColor,
+          "maximumTrackImage":
+            UtilsRN.option_map(convertImageSource, maximumTrackImage),
+          "minimumTrackImage":
+            UtilsRN.option_map(convertImageSource, minimumTrackImage),
+          "thumbImage":
+            UtilsRN.option_map(convertImageSource, thumbImage),
+          "trackImage":
+            UtilsRN.option_map(convertImageSource, trackImage),
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/snapshotViewIOS.re
+++ b/src/components/snapshotViewIOS.re
@@ -31,12 +31,10 @@ let make =
     ~reactClass=snapshotViewIOS,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "onSnapshotReady": fromOption(onSnapshotReady),
-            "testIdentifier": fromOption(testIdentifier),
-          }
-        ),
+        {
+          "onSnapshotReady": onSnapshotReady,
+          "testIdentifier": testIdentifier,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/statusBar.re
+++ b/src/components/statusBar.re
@@ -31,7 +31,7 @@ let setBarStyle = (style, ~animated=?, ()) =>
     | `lightContent => "light-content"
     | `darkContent => "dark-content"
     },
-    Js.Undefined.fromOption(UtilsRN.optBoolToOptJsBoolean(animated)),
+    Js.Undefined.fromOption(animated),
   );
 
 [@bs.scope "StatusBar"] [@bs.module "react-native"]
@@ -48,7 +48,7 @@ external _setBackgroundColor : (string, Js.Undefined.t(bool)) => unit =
 let setBackgroundColor = (color, ~animated=?, ()) =>
   _setBackgroundColor(
     color,
-    Js.Undefined.fromOption(UtilsRN.optBoolToOptJsBoolean(animated)),
+    Js.Undefined.fromOption(animated),
   );
 
 [@bs.scope "StatusBar"] [@bs.module "react-native"]
@@ -69,41 +69,31 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=statusBar,
     ~props=
-      Js.Undefined.(
-        {
-          "animated": fromOption(UtilsRN.optBoolToOptJsBoolean(animated)),
-          "barStyle":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `default => "default"
-                  | `lightContent => "light-content"
-                  | `darkContent => "dark-content"
-                  },
-                barStyle,
-              ),
-            ),
-          "backgroundColor": fromOption(backgroundColor),
-          "hidden": fromOption(UtilsRN.optBoolToOptJsBoolean(hidden)),
-          "translucent":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(translucent)),
-          "networkActivityIndicatorVisible":
-            fromOption(
-              UtilsRN.optBoolToOptJsBoolean(networkActivityIndicatorVisible),
-            ),
-          "showHideTransition":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `none => "none"
-                  | `fade => "fade"
-                  | `slide => "slide"
-                  },
-                showHideTransition,
-              ),
-            ),
-        }
-      ),
+      {
+        "animated": animated,
+        "barStyle":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `default => "default"
+              | `lightContent => "light-content"
+              | `darkContent => "dark-content"
+              },
+            barStyle,
+          ),
+        "backgroundColor": backgroundColor,
+        "hidden": hidden,
+        "translucent": translucent,
+        "networkActivityIndicatorVisible": networkActivityIndicatorVisible,
+        "showHideTransition":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `none => "none"
+              | `fade => "fade"
+              | `slide => "slide"
+              },
+            showHideTransition,
+          ),
+      },
   );

--- a/src/components/switch.re
+++ b/src/components/switch.re
@@ -33,16 +33,14 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "value": fromOption(UtilsRN.optBoolToOptJsBoolean(value)),
-            "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-            "onValueChange": fromOption(onValueChange),
-            "onTintColor": fromOption(onTintColor),
-            "thumbTintColor": fromOption(thumbTintColor),
-            "tintColor": fromOption(tintColor),
-          }
-        ),
+        {
+          "value": value,
+          "disabled": disabled,
+          "onValueChange": onValueChange,
+          "onTintColor": onTintColor,
+          "thumbTintColor": thumbTintColor,
+          "tintColor": tintColor,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/tabBarIOS.re
+++ b/src/components/tabBarIOS.re
@@ -37,23 +37,18 @@ module Item = {
       ~reactClass=tabBarItemIOS,
       ~props=
         Props.extendView(
-          Js.Undefined.(
-            {
-              "badgeColor": fromOption(badgeColor),
-              "title": fromOption(title),
-              "badge": fromOption(badge),
-              "icon": fromOption(icon),
-              "onPress": fromOption(onPress),
-              "renderAsOriginal":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(renderAsOriginal)),
-              "selected":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(selected)),
-              "selectedIcon": fromOption(selectedIcon),
-              "style": fromOption(style),
-              "isTVSelectable":
-                fromOption(UtilsRN.optBoolToOptJsBoolean(isTVSelectable)),
-            }
-          ),
+          {
+            "badgeColor": badgeColor,
+            "title": title,
+            "badge": badge,
+            "icon": icon,
+            "onPress": onPress,
+            "renderAsOriginal": renderAsOriginal,
+            "selected": selected,
+            "selectedIcon": selectedIcon,
+            "style": style,
+            "isTVSelectable": isTVSelectable,
+          },
           ~accessibilityLabel?,
           ~accessible?,
           ~hitSlop?,
@@ -114,28 +109,23 @@ let make =
     ~reactClass=tabBarIOS,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "barTintColor": fromOption(barTintColor),
-            "itemPositioning":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `fill => "fill"
-                    | `center => "center"
-                    | `auto => "auto"
-                    },
-                  itemPositioning,
-                ),
-              ),
-            "tintColor": fromOption(tintColor),
-            "translucent":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(translucent)),
-            "unselectedItemTintColor": fromOption(unselectedItemTintColor),
-            "unselectedTintColor": fromOption(unselectedTintColor),
-          }
-        ),
+        {
+          "barTintColor": barTintColor,
+          "itemPositioning":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `fill => "fill"
+                | `center => "center"
+                | `auto => "auto"
+                },
+              itemPositioning,
+            ),
+          "tintColor": tintColor,
+          "translucent": translucent,
+          "unselectedItemTintColor": unselectedItemTintColor,
+          "unselectedTintColor": unselectedTintColor,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/text.re
+++ b/src/components/text.re
@@ -52,54 +52,39 @@ module CreateComponent = (Impl: View.Impl) : TextComponent => {
     ReasonReact.wrapJsForReason(
       ~reactClass=Impl.view,
       ~props=
-        Js.Undefined.(
-          {
-            "accessible":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-            "allowFontScaling":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(allowFontScaling)),
-            "ellipsizeMode":
-              fromOption(
-                UtilsRN.option_map(
-                  fun
-                  | `head => "head"
-                  | `middle => "middle"
-                  | `tail => "tail"
-                  | `clip => "clip",
-                  ellipsizeMode,
-                ),
-              ),
-            "numberOfLines": fromOption(numberOfLines),
-            "onLayout": fromOption(onLayout),
-            "onLongPress": fromOption(onLongPress),
-            "onPress": fromOption(onPress),
-            "pressRetentionOffset": fromOption(pressRetentionOffset),
-            "selectable":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(selectable)),
-            "style": fromOption(style),
-            "testID": fromOption(testID),
-            "selectionColor": fromOption(selectionColor),
-            "textBreakStrategy":
-              fromOption(
-                UtilsRN.option_map(
-                  fun
-                  | `simple => "simple"
-                  | `highQuality => "highQuality"
-                  | `balanced => "balanced",
-                  textBreakStrategy,
-                ),
-              ),
-            "adjustsFontSizeToFit":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(adjustsFontSizeToFit),
-              ),
-            "minimumFontScale": fromOption(minimumFontScale),
-            "suppressHighlighting":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(suppressHighlighting),
-              ),
-          }
-        ),
+        {
+          "accessible": accessible,
+          "allowFontScaling": allowFontScaling,
+          "ellipsizeMode":
+            UtilsRN.option_map(
+              fun
+              | `head => "head"
+              | `middle => "middle"
+              | `tail => "tail"
+              | `clip => "clip",
+              ellipsizeMode,
+            ),
+          "numberOfLines": numberOfLines,
+          "onLayout": onLayout,
+          "onLongPress": onLongPress,
+          "onPress": onPress,
+          "pressRetentionOffset": pressRetentionOffset,
+          "selectable": selectable,
+          "style": style,
+          "testID": testID,
+          "selectionColor": selectionColor,
+          "textBreakStrategy":
+            UtilsRN.option_map(
+              fun
+              | `simple => "simple"
+              | `highQuality => "highQuality"
+              | `balanced => "balanced",
+              textBreakStrategy,
+            ),
+          "adjustsFontSizeToFit": adjustsFontSizeToFit,
+          "minimumFontScale": minimumFontScale,
+          "suppressHighlighting": suppressHighlighting,
+        },
       switch (value) {
       | Some(string) =>
         Array.append([|ReasonReact.string(string)|], children)

--- a/src/components/textInput.re
+++ b/src/components/textInput.re
@@ -75,168 +75,139 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "autoCapitalize":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `none => "none"
-                    | `sentences => "sentences"
-                    | `words => "words"
-                    | `characters => "characters"
-                    },
-                  autoCapitalize,
-                ),
+        {
+          "autoCapitalize":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `none => "none"
+                | `sentences => "sentences"
+                | `words => "words"
+                | `characters => "characters"
+                },
+              autoCapitalize,
+            ),
+          "autoCorrect": autoCorrect,
+          "autoFocus": autoFocus,
+          "blurOnSubmit": blurOnSubmit,
+          "caretHidden": caretHidden,
+          "defaultValue": defaultValue,
+          "editable": editable ,
+          "keyboardType":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `default => "default"
+                | `emailAddress => "email-address"
+                | `numeric => "numeric"
+                | `phonePad => "phone-pad"
+                | `asciiCapable => "ascii-capable"
+                | `numbersAndPunctuation => "numbers-and-punctuation"
+                | `url => "url"
+                | `numberPad => "number-pad"
+                | `namePhonePad => "name-phone-pad"
+                | `decimalPad => "decimal-pad"
+                | `twitter => "twitter"
+                | `webSearch => "web-search"
+                },
+              keyboardType,
+            ),
+          "maxLength": maxLength,
+          "multiline": multiline,
+          "onBlur": onBlur,
+          "onChange": onChange,
+          "onChangeText": onChangeText,
+          "onContentSizeChange": onContentSizeChange,
+          "onEndEditing": onEndEditing,
+          "onFocus": onFocus,
+          "onScroll": onScroll,
+          "onSelectionChange": onSelectionChange,
+          "onSubmitEditing": onSubmitEditing,
+          "placeholder": placeholder,
+          "placeholderTextColor": placeholderTextColor,
+          "returnKeyType":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `done_ => "done"
+                | `go => "go"
+                | `next => "next"
+                | `search => "search"
+                | `send => "send"
+                | `none => "none"
+                | `previous => "previous"
+                | `default => "default"
+                | `emergencyCall => "emergencyCall"
+                | `google => "google"
+                | `join => "join"
+                | `route => "route"
+                | `yahoo => "yahoo"
+                },
+              returnKeyType,
+            ),
+          "secureTextEntry": secureTextEntry,
+          "selectTextOnFocus": selectTextOnFocus,
+          "selection": selection,
+          "selectionColor": selectionColor,
+          "value": value,
+          "disableFullscreenUI": disableFullscreenUI,
+          /* TODO */
+          "inlineImageLeft": inlineImageLeft,
+          "inlineImagePadding": inlineImagePadding,
+          "numberOfLines": numberOfLines,
+          "returnKeyLabel": returnKeyLabel,
+          "textBreakStrategy":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `simple => "simple"
+                | `highQuality => "highQuality"
+                | `balanced => "balanced"
+                },
+              textBreakStrategy,
+            ),
+          "underlineColorAndroid": underlineColorAndroid,
+          "clearButtonMode":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `never => "never"
+                | `whileEditing => "while-editing"
+                | `unlessEditing => "unless-editing"
+                | `always => "always"
+                },
+              clearButtonMode,
+            ),
+          "clearTextOnFocus": clearTextOnFocus,
+          "dataDetectorTypes":
+            UtilsRN.option_map(
+              Array.map(x =>
+                switch (x) {
+                | `phoneNumber => "phoneNumber"
+                | `link => "link"
+                | `calendarEvent => "calendarEvent"
+                | `none => "none"
+                | `all => "all"
+                }
               ),
-            "autoCorrect":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(autoCorrect)),
-            "autoFocus":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(autoFocus)),
-            "blurOnSubmit":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(blurOnSubmit)),
-            "caretHidden":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(caretHidden)),
-            "defaultValue": fromOption(defaultValue),
-            "editable": fromOption(UtilsRN.optBoolToOptJsBoolean(editable)),
-            "keyboardType":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `default => "default"
-                    | `emailAddress => "email-address"
-                    | `numeric => "numeric"
-                    | `phonePad => "phone-pad"
-                    | `asciiCapable => "ascii-capable"
-                    | `numbersAndPunctuation => "numbers-and-punctuation"
-                    | `url => "url"
-                    | `numberPad => "number-pad"
-                    | `namePhonePad => "name-phone-pad"
-                    | `decimalPad => "decimal-pad"
-                    | `twitter => "twitter"
-                    | `webSearch => "web-search"
-                    },
-                  keyboardType,
-                ),
-              ),
-            "maxLength": fromOption(maxLength),
-            "multiline":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(multiline)),
-            "onBlur": fromOption(onBlur),
-            "onChange": fromOption(onChange),
-            "onChangeText": fromOption(onChangeText),
-            "onContentSizeChange": fromOption(onContentSizeChange),
-            "onEndEditing": fromOption(onEndEditing),
-            "onFocus": fromOption(onFocus),
-            "onScroll": fromOption(onScroll),
-            "onSelectionChange": fromOption(onSelectionChange),
-            "onSubmitEditing": fromOption(onSubmitEditing),
-            "placeholder": fromOption(placeholder),
-            "placeholderTextColor": fromOption(placeholderTextColor),
-            "returnKeyType":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `done_ => "done"
-                    | `go => "go"
-                    | `next => "next"
-                    | `search => "search"
-                    | `send => "send"
-                    | `none => "none"
-                    | `previous => "previous"
-                    | `default => "default"
-                    | `emergencyCall => "emergencyCall"
-                    | `google => "google"
-                    | `join => "join"
-                    | `route => "route"
-                    | `yahoo => "yahoo"
-                    },
-                  returnKeyType,
-                ),
-              ),
-            "secureTextEntry":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(secureTextEntry)),
-            "selectTextOnFocus":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(selectTextOnFocus)),
-            "selection": fromOption(selection),
-            "selectionColor": fromOption(selectionColor),
-            "value": fromOption(value),
-            "disableFullscreenUI":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(disableFullscreenUI)),
-            /* TODO */
-            "inlineImageLeft": fromOption(inlineImageLeft),
-            "inlineImagePadding": fromOption(inlineImagePadding),
-            "numberOfLines": fromOption(numberOfLines),
-            "returnKeyLabel": fromOption(returnKeyLabel),
-            "textBreakStrategy":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `simple => "simple"
-                    | `highQuality => "highQuality"
-                    | `balanced => "balanced"
-                    },
-                  textBreakStrategy,
-                ),
-              ),
-            "underlineColorAndroid": fromOption(underlineColorAndroid),
-            "clearButtonMode":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `never => "never"
-                    | `whileEditing => "while-editing"
-                    | `unlessEditing => "unless-editing"
-                    | `always => "always"
-                    },
-                  clearButtonMode,
-                ),
-              ),
-            "clearTextOnFocus":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(clearTextOnFocus)),
-            "dataDetectorTypes":
-              fromOption(
-                UtilsRN.option_map(
-                  Array.map(x =>
-                    switch (x) {
-                    | `phoneNumber => "phoneNumber"
-                    | `link => "link"
-                    | `calendarEvent => "calendarEvent"
-                    | `none => "none"
-                    | `all => "all"
-                    }
-                  ),
-                  dataDetectorTypes,
-                ),
-              ),
-            "enablesReturnKeyAutomatically":
-              fromOption(
-                UtilsRN.optBoolToOptJsBoolean(enablesReturnKeyAutomatically),
-              ),
-            "keyboardAppearance":
-              fromOption(
-                UtilsRN.option_map(
-                  x =>
-                    switch (x) {
-                    | `default => "never"
-                    | `light => "light"
-                    | `dark => "dark"
-                    },
-                  keyboardAppearance,
-                ),
-              ),
-            "onKeyPress": fromOption(onKeyPress),
-            "selectionState": fromOption(selectionState),
-            "spellCheck":
-              fromOption(UtilsRN.optBoolToOptJsBoolean(spellCheck)),
-            "inputAccessoryViewID": fromOption(inputAccessoryViewID),
-          }
-        ),
+              dataDetectorTypes,
+            ),
+          "enablesReturnKeyAutomatically": enablesReturnKeyAutomatically,
+          "keyboardAppearance":
+            UtilsRN.option_map(
+              x =>
+                switch (x) {
+                | `default => "never"
+                | `light => "light"
+                | `dark => "dark"
+                },
+              keyboardAppearance,
+            ),
+          "onKeyPress": onKeyPress,
+          "selectionState": selectionState,
+          "spellCheck": spellCheck,
+          "inputAccessoryViewID": inputAccessoryViewID,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/touchableHighlight.re
+++ b/src/components/touchableHighlight.re
@@ -28,69 +28,62 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        {
-          "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "delayLongPress": fromOption(delayLongPress),
-          "delayPressIn": fromOption(delayPressIn),
-          "delayPressOut": fromOption(delayPressOut),
-          "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-          "hitSlop": fromOption(hitSlop),
-          "onLayout": fromOption(onLayout),
-          "onPress": fromOption(onPress),
-          "onPressIn": fromOption(onPressIn),
-          "onPressOut": fromOption(onPressOut),
-          "pressRetentionOffset": fromOption(pressRetentionOffset),
-          "accessibilityComponentType":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `none => "none"
-                  | `button => "button"
-                  | `radiobutton_checked => "radiobutton_checked-none"
-                  | `radiobutton_unchecked => "radiobutton_unchecked"
-                  },
-                accessibilityComponentType,
-              ),
-            ),
-          "accessibilityTraits":
-            fromOption(
-              UtilsRN.option_map(
-                traits => {
-                  let to_string =
-                    fun
-                    | `none => "none"
-                    | `button => "button"
-                    | `link => "link"
-                    | `header => "header"
-                    | `search => "search"
-                    | `image => "image"
-                    | `selected => "selected"
-                    | `plays => "plays"
-                    | `key => "key"
-                    | `text => "text"
-                    | `summary => "summary"
-                    | `disabled => "disabled"
-                    | `frequentUpdates => "frequentUpdates"
-                    | `startsMedia => "startsMedia"
-                    | `adjustable => "adjustable"
-                    | `allowsDirectInteraction => "allowsDirectInteraction"
-                    | `pageTurn => "pageTurn";
-                  traits |> List.map(to_string) |> Array.of_list;
-                },
-                accessibilityTraits,
-              ),
-            ),
-          "activeOpacity": fromOption(activeOpacity),
-          "onHideUnderlay": fromOption(onHideUnderlay),
-          "onShowUnderlay": fromOption(onShowUnderlay),
-          "style": fromOption(style),
-          "underlayColor": fromOption(underlayColor),
-          "hasTVPreferredFocus":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(hasTVPreferredFocus)),
-          "tvParallaxProperties": fromOption(tvParallaxProperties),
-        }
-      ),
+      {
+        "accessible": accessible,
+        "accessibilityLabel": accessibilityLabel,
+        "delayLongPress": delayLongPress,
+        "delayPressIn": delayPressIn,
+        "delayPressOut": delayPressOut,
+        "disabled": disabled,
+        "hitSlop": hitSlop,
+        "onLayout": onLayout,
+        "onPress": onPress,
+        "onPressIn": onPressIn,
+        "onPressOut": onPressOut,
+        "pressRetentionOffset": pressRetentionOffset,
+        "accessibilityComponentType":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `none => "none"
+              | `button => "button"
+              | `radiobutton_checked => "radiobutton_checked-none"
+              | `radiobutton_unchecked => "radiobutton_unchecked"
+              },
+            accessibilityComponentType,
+          ),
+        "accessibilityTraits":
+          UtilsRN.option_map(
+            traits => {
+              let to_string =
+                fun
+                | `none => "none"
+                | `button => "button"
+                | `link => "link"
+                | `header => "header"
+                | `search => "search"
+                | `image => "image"
+                | `selected => "selected"
+                | `plays => "plays"
+                | `key => "key"
+                | `text => "text"
+                | `summary => "summary"
+                | `disabled => "disabled"
+                | `frequentUpdates => "frequentUpdates"
+                | `startsMedia => "startsMedia"
+                | `adjustable => "adjustable"
+                | `allowsDirectInteraction => "allowsDirectInteraction"
+                | `pageTurn => "pageTurn";
+              traits |> List.map(to_string) |> Array.of_list;
+            },
+            accessibilityTraits,
+          ),
+        "activeOpacity": activeOpacity,
+        "onHideUnderlay": onHideUnderlay,
+        "onShowUnderlay": onShowUnderlay,
+        "style": style,
+        "underlayColor": underlayColor,
+        "hasTVPreferredFocus": hasTVPreferredFocus,
+        "tvParallaxProperties": tvParallaxProperties,
+      },
   );

--- a/src/components/touchableNativeFeedback.re
+++ b/src/components/touchableNativeFeedback.re
@@ -40,66 +40,59 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        {
-          "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "delayLongPress": fromOption(delayLongPress),
-          "delayPressIn": fromOption(delayPressIn),
-          "delayPressOut": fromOption(delayPressOut),
-          "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-          "hitSlop": fromOption(hitSlop),
-          "onLayout": fromOption(onLayout),
-          "onLongPress": fromOption(onLongPress),
-          "onPress": fromOption(onPress),
-          "background": fromOption(background),
-          "onPressIn": fromOption(onPressIn),
-          "onPressOut": fromOption(onPressOut),
-          "pressRetentionOffset": fromOption(pressRetentionOffset),
-          "style": fromOption(style),
-          "useForeground":
-            fromOption(UtilsRN.optBoolToOptJsBoolean(useForeground)),
-          "accessibilityComponentType":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `none => "none"
-                  | `button => "button"
-                  | `radiobutton_checked => "radiobutton_checked-none"
-                  | `radiobutton_unchecked => "radiobutton_unchecked"
-                  },
-                accessibilityComponentType,
-              ),
-            ),
-          "accessibilityTraits":
-            fromOption(
-              UtilsRN.option_map(
-                traits => {
-                  let to_string =
-                    fun
-                    | `none => "none"
-                    | `button => "button"
-                    | `link => "link"
-                    | `header => "header"
-                    | `search => "search"
-                    | `image => "image"
-                    | `selected => "selected"
-                    | `plays => "plays"
-                    | `key => "key"
-                    | `text => "text"
-                    | `summary => "summary"
-                    | `disabled => "disabled"
-                    | `frequentUpdates => "frequentUpdates"
-                    | `startsMedia => "startsMedia"
-                    | `adjustable => "adjustable"
-                    | `allowsDirectInteraction => "allowsDirectInteraction"
-                    | `pageTurn => "pageTurn";
-                  traits |> List.map(to_string) |> Array.of_list;
-                },
-                accessibilityTraits,
-              ),
-            ),
-        }
-      ),
+      {
+        "accessible": accessible,
+        "accessibilityLabel": accessibilityLabel,
+        "delayLongPress": delayLongPress,
+        "delayPressIn": delayPressIn,
+        "delayPressOut": delayPressOut,
+        "disabled": disabled,
+        "hitSlop": hitSlop,
+        "onLayout": onLayout,
+        "onLongPress": onLongPress,
+        "onPress": onPress,
+        "background": background,
+        "onPressIn": onPressIn,
+        "onPressOut": onPressOut,
+        "pressRetentionOffset": pressRetentionOffset,
+        "style": style,
+        "useForeground": useForeground,
+        "accessibilityComponentType":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `none => "none"
+              | `button => "button"
+              | `radiobutton_checked => "radiobutton_checked-none"
+              | `radiobutton_unchecked => "radiobutton_unchecked"
+              },
+            accessibilityComponentType,
+          ),
+        "accessibilityTraits":
+          UtilsRN.option_map(
+            traits => {
+              let to_string =
+                fun
+                | `none => "none"
+                | `button => "button"
+                | `link => "link"
+                | `header => "header"
+                | `search => "search"
+                | `image => "image"
+                | `selected => "selected"
+                | `plays => "plays"
+                | `key => "key"
+                | `text => "text"
+                | `summary => "summary"
+                | `disabled => "disabled"
+                | `frequentUpdates => "frequentUpdates"
+                | `startsMedia => "startsMedia"
+                | `adjustable => "adjustable"
+                | `allowsDirectInteraction => "allowsDirectInteraction"
+                | `pageTurn => "pageTurn";
+              traits |> List.map(to_string) |> Array.of_list;
+            },
+            accessibilityTraits,
+          ),
+      },
   );

--- a/src/components/touchableOpacity.re
+++ b/src/components/touchableOpacity.re
@@ -30,66 +30,60 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        {
-          "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "delayLongPress": fromOption(delayLongPress),
-          "delayPressIn": fromOption(delayPressIn),
-          "delayPressOut": fromOption(delayPressOut),
-          "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-          "hitSlop": fromOption(hitSlop),
-          "style": fromOption(style),
-          "onLayout": fromOption(onLayout),
-          "onPress": fromOption(onPress),
-          "onLongPress": fromOption(onLongPress),
-          "onPressIn": fromOption(onPressIn),
-          "onPressOut": fromOption(onPressOut),
-          "pressRetentionOffset": fromOption(pressRetentionOffset),
-          "accessibilityComponentType":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `none => "none"
-                  | `button => "button"
-                  | `radiobutton_checked => "radiobutton_checked-none"
-                  | `radiobutton_unchecked => "radiobutton_unchecked"
-                  },
-                accessibilityComponentType,
-              ),
-            ),
-          "accessibilityTraits":
-            fromOption(
-              UtilsRN.option_map(
-                traits => {
-                  let to_string =
-                    fun
-                    | `none => "none"
-                    | `button => "button"
-                    | `link => "link"
-                    | `header => "header"
-                    | `search => "search"
-                    | `image => "image"
-                    | `selected => "selected"
-                    | `plays => "plays"
-                    | `key => "key"
-                    | `text => "text"
-                    | `summary => "summary"
-                    | `disabled => "disabled"
-                    | `frequentUpdates => "frequentUpdates"
-                    | `startsMedia => "startsMedia"
-                    | `adjustable => "adjustable"
-                    | `allowsDirectInteraction => "allowsDirectInteraction"
-                    | `pageTurn => "pageTurn";
-                  traits |> List.map(to_string) |> Array.of_list;
-                },
-                accessibilityTraits,
-              ),
-            ),
-          "focusedOpacity": fromOption(focusedOpacity),
-          "activeOpacity": fromOption(activeOpacity),
-          "tvParallaxProperties": fromOption(tvParallaxProperties),
-        }
-      ),
+      {
+        "accessible": accessible,
+        "accessibilityLabel": accessibilityLabel,
+        "delayLongPress": delayLongPress,
+        "delayPressIn": delayPressIn,
+        "delayPressOut": delayPressOut,
+        "disabled": disabled,
+        "hitSlop": hitSlop,
+        "style": style,
+        "onLayout": onLayout,
+        "onPress": onPress,
+        "onLongPress": onLongPress,
+        "onPressIn": onPressIn,
+        "onPressOut": onPressOut,
+        "pressRetentionOffset": pressRetentionOffset,
+        "accessibilityComponentType":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `none => "none"
+              | `button => "button"
+              | `radiobutton_checked => "radiobutton_checked-none"
+              | `radiobutton_unchecked => "radiobutton_unchecked"
+              },
+            accessibilityComponentType,
+          ),
+        "accessibilityTraits":
+          UtilsRN.option_map(
+            traits => {
+              let to_string =
+                fun
+                | `none => "none"
+                | `button => "button"
+                | `link => "link"
+                | `header => "header"
+                | `search => "search"
+                | `image => "image"
+                | `selected => "selected"
+                | `plays => "plays"
+                | `key => "key"
+                | `text => "text"
+                | `summary => "summary"
+                | `disabled => "disabled"
+                | `frequentUpdates => "frequentUpdates"
+                | `startsMedia => "startsMedia"
+                | `adjustable => "adjustable"
+                | `allowsDirectInteraction => "allowsDirectInteraction"
+                | `pageTurn => "pageTurn";
+              traits |> List.map(to_string) |> Array.of_list;
+            },
+            accessibilityTraits,
+          ),
+        "focusedOpacity": focusedOpacity,
+        "activeOpacity": activeOpacity,
+        "tvParallaxProperties": tvParallaxProperties,
+      },
   );

--- a/src/components/touchableWithoutFeedback.re
+++ b/src/components/touchableWithoutFeedback.re
@@ -23,63 +23,57 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        {
-          "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-          "accessibilityLabel": fromOption(accessibilityLabel),
-          "delayLongPress": fromOption(delayLongPress),
-          "delayPressIn": fromOption(delayPressIn),
-          "delayPressOut": fromOption(delayPressOut),
-          "disabled": fromOption(UtilsRN.optBoolToOptJsBoolean(disabled)),
-          "hitSlop": fromOption(hitSlop),
-          "onLayout": fromOption(onLayout),
-          "onLongPress": fromOption(onLongPress),
-          "onPress": fromOption(onPress),
-          "onPressIn": fromOption(onPressIn),
-          "onPressOut": fromOption(onPressOut),
-          "pressRetentionOffset": fromOption(pressRetentionOffset),
-          "style": fromOption(style),
-          "accessibilityComponentType":
-            fromOption(
-              UtilsRN.option_map(
-                x =>
-                  switch (x) {
-                  | `none => "none"
-                  | `button => "button"
-                  | `radiobutton_checked => "radiobutton_checked-none"
-                  | `radiobutton_unchecked => "radiobutton_unchecked"
-                  },
-                accessibilityComponentType,
-              ),
-            ),
-          "accessibilityTraits":
-            fromOption(
-              UtilsRN.option_map(
-                traits => {
-                  let to_string =
-                    fun
-                    | `none => "none"
-                    | `button => "button"
-                    | `link => "link"
-                    | `header => "header"
-                    | `search => "search"
-                    | `image => "image"
-                    | `selected => "selected"
-                    | `plays => "plays"
-                    | `key => "key"
-                    | `text => "text"
-                    | `summary => "summary"
-                    | `disabled => "disabled"
-                    | `frequentUpdates => "frequentUpdates"
-                    | `startsMedia => "startsMedia"
-                    | `adjustable => "adjustable"
-                    | `allowsDirectInteraction => "allowsDirectInteraction"
-                    | `pageTurn => "pageTurn";
-                  traits |> List.map(to_string) |> Array.of_list;
-                },
-                accessibilityTraits,
-              ),
-            ),
-        }
-      ),
+      {
+        "accessible": accessible,
+        "accessibilityLabel": accessibilityLabel,
+        "delayLongPress": delayLongPress,
+        "delayPressIn": delayPressIn,
+        "delayPressOut": delayPressOut,
+        "disabled": disabled,
+        "hitSlop": hitSlop,
+        "onLayout": onLayout,
+        "onLongPress": onLongPress,
+        "onPress": onPress,
+        "onPressIn": onPressIn,
+        "onPressOut": onPressOut,
+        "pressRetentionOffset": pressRetentionOffset,
+        "style": style,
+        "accessibilityComponentType":
+          UtilsRN.option_map(
+            x =>
+              switch (x) {
+              | `none => "none"
+              | `button => "button"
+              | `radiobutton_checked => "radiobutton_checked-none"
+              | `radiobutton_unchecked => "radiobutton_unchecked"
+              },
+            accessibilityComponentType,
+          ),
+        "accessibilityTraits":
+          UtilsRN.option_map(
+            traits => {
+              let to_string =
+                fun
+                | `none => "none"
+                | `button => "button"
+                | `link => "link"
+                | `header => "header"
+                | `search => "search"
+                | `image => "image"
+                | `selected => "selected"
+                | `plays => "plays"
+                | `key => "key"
+                | `text => "text"
+                | `summary => "summary"
+                | `disabled => "disabled"
+                | `frequentUpdates => "frequentUpdates"
+                | `startsMedia => "startsMedia"
+                | `adjustable => "adjustable"
+                | `allowsDirectInteraction => "allowsDirectInteraction"
+                | `pageTurn => "pageTurn";
+              traits |> List.map(to_string) |> Array.of_list;
+            },
+            accessibilityTraits,
+          ),
+      },
   );

--- a/src/components/viewPagerAndroid.re
+++ b/src/components/viewPagerAndroid.re
@@ -38,26 +38,22 @@ let make =
     ~reactClass=view,
     ~props=
       Props.extendView(
-        Js.Undefined.(
-          {
-            "initialPage": fromOption(initialPage),
-            "onPageScroll": fromOption(onPageScroll),
-            "onPageScrollStateChanged": fromOption(onPageScrollStateChanged),
-            "onPageSelected": fromOption(onPageSelected),
-            "pageMargin": fromOption(pageMargin),
-            "keyboardDismissMode":
-              fromOption(
-                UtilsRN.option_map(
-                  fun
-                  | `none => "none"
-                  | `onDrag => "on-drag",
-                  keyboardDismissMode,
-                ),
-              ),
-            "peekEnabled": fromOption(peekEnabled),
-            "scrollEnabled": fromOption(scrollEnabled),
-          }
-        ),
+        {
+          "initialPage": initialPage,
+          "onPageScroll": onPageScroll,
+          "onPageScrollStateChanged": onPageScrollStateChanged,
+          "onPageSelected": onPageSelected,
+          "pageMargin": pageMargin,
+          "keyboardDismissMode":
+            UtilsRN.option_map(
+              fun
+              | `none => "none"
+              | `onDrag => "on-drag",
+              keyboardDismissMode,
+            ),
+          "peekEnabled": peekEnabled,
+          "scrollEnabled": scrollEnabled,
+        },
         ~accessibilityLabel?,
         ~accessible?,
         ~hitSlop?,

--- a/src/components/webView.re
+++ b/src/components/webView.re
@@ -117,104 +117,92 @@ let make =
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
     ~props=
-      Js.Undefined.(
-        Props.extendView(
-          ~accessibilityLabel?,
-          ~accessible?,
-          ~hitSlop?,
-          ~onAccessibilityTap?,
-          ~onLayout?,
-          ~onMagicTap?,
-          ~responderHandlers?,
-          ~pointerEvents?,
-          ~removeClippedSubviews?,
-          ~style?,
-          ~testID?,
-          ~accessibilityComponentType?,
-          ~accessibilityLiveRegion?,
-          ~collapsable?,
-          ~importantForAccessibility?,
-          ~needsOffscreenAlphaCompositing?,
-          ~renderToHardwareTextureAndroid?,
-          ~accessibilityTraits?,
-          ~accessibilityViewIsModal?,
-          ~shouldRasterizeIOS?,
-          {
-            "source": fromOption(source),
-            "style": fromOption(style),
-            "automaticallyAdjustContentInsets":
-              fromOption(automaticallyAdjustContentInsets),
-            "contentInsets": fromOption(contentInsets),
-            "injectJavaScript": fromOption(injectJavaScript),
-            "injectedJavaScript": fromOption(injectedJavaScript),
-            "mediaPlaybackRequiresUserAction":
-              fromOption(mediaPlaybackRequiresUserAction),
-            "onError": fromOption(onError),
-            "onLoad": fromOption(onLoad),
-            "onLoadEnd": fromOption(onLoadEnd),
-            "onLoadStart": fromOption(onLoadStart),
-            "onMessage": fromOption(onMessage),
-            "onNavigationStateChange": fromOption(onNavigationStateChange),
-            "renderError": fromOption(renderError),
-            "renderLoading": fromOption(renderLoading),
-            "scalesPageToFit": fromOption(scalesPageToFit),
-            "startInLoadingState": fromOption(startInLoadingState),
-            "domStorageEnabled": fromOption(domStorageEnabled),
-            "javaScriptEnabled": fromOption(javaScriptEnabled),
-            "mixedContentMode":
-              fromOption(
-                UtilsRN.option_map(
-                  contentMode => {
-                    let to_string =
-                      fun
-                      | `never => "never"
-                      | `always => "always"
-                      | `compatibility => "compatibility";
-                    contentMode |> List.map(to_string) |> Array.of_list;
-                  },
-                  mixedContentMode,
-                ),
-              ),
-            "thirdPartyCookiesEnabled": fromOption(thirdPartyCookiesEnabled),
-            "userAgent": fromOption(userAgent),
-            "allowsInlineMediaPlayback":
-              fromOption(allowsInlineMediaPlayback),
-            "bounces": fromOption(bounces),
-            "dataDetectorTypes":
-              fromOption(
-                UtilsRN.option_map(
-                  dataDetectorType => {
-                    let to_string =
-                      fun
-                      | `phoneNumber => "phoneNumber"
-                      | `link => "link"
-                      | `address => "address"
-                      | `calendarEvent => "calendarEvent"
-                      | `none => "none"
-                      | `all => "all";
-                    dataDetectorType |> List.map(to_string) |> Array.of_list;
-                  },
-                  dataDetectorTypes,
-                ),
-              ),
-            "decelerationRate":
-              fromOption(
-                UtilsRN.option_map(
-                  rate => {
-                    let to_float =
-                      fun
-                      | `normal => 0.998
-                      | `fast => 0.99
-                      | `value(f) => f;
-                    rate |> List.map(to_float) |> Array.of_list;
-                  },
-                  decelerationRate,
-                ),
-              ),
-            "onShouldStartLoadWithRequest":
-              fromOption(onShouldStartLoadWithRequest),
-            "scrollEnabled": fromOption(scrollEnabled),
-          },
-        )
-      ),
+      Props.extendView(
+        ~accessibilityLabel?,
+        ~accessible?,
+        ~hitSlop?,
+        ~onAccessibilityTap?,
+        ~onLayout?,
+        ~onMagicTap?,
+        ~responderHandlers?,
+        ~pointerEvents?,
+        ~removeClippedSubviews?,
+        ~style?,
+        ~testID?,
+        ~accessibilityComponentType?,
+        ~accessibilityLiveRegion?,
+        ~collapsable?,
+        ~importantForAccessibility?,
+        ~needsOffscreenAlphaCompositing?,
+        ~renderToHardwareTextureAndroid?,
+        ~accessibilityTraits?,
+        ~accessibilityViewIsModal?,
+        ~shouldRasterizeIOS?,
+        {
+          "source": source,
+          "style": style,
+          "automaticallyAdjustContentInsets": automaticallyAdjustContentInsets,
+          "contentInsets": contentInsets,
+          "injectJavaScript": injectJavaScript,
+          "injectedJavaScript": injectedJavaScript,
+          "mediaPlaybackRequiresUserAction": mediaPlaybackRequiresUserAction,
+          "onError": onError,
+          "onLoad": onLoad,
+          "onLoadEnd": onLoadEnd,
+          "onLoadStart": onLoadStart,
+          "onMessage": onMessage,
+          "onNavigationStateChange": onNavigationStateChange,
+          "renderError": renderError,
+          "renderLoading": renderLoading,
+          "scalesPageToFit": scalesPageToFit,
+          "startInLoadingState": startInLoadingState,
+          "domStorageEnabled": domStorageEnabled,
+          "javaScriptEnabled": javaScriptEnabled,
+          "mixedContentMode":
+            UtilsRN.option_map(
+              contentMode => {
+                let to_string =
+                  fun
+                  | `never => "never"
+                  | `always => "always"
+                  | `compatibility => "compatibility";
+                contentMode |> List.map(to_string) |> Array.of_list;
+              },
+              mixedContentMode,
+            ),
+          "thirdPartyCookiesEnabled": thirdPartyCookiesEnabled,
+          "userAgent": userAgent,
+          "allowsInlineMediaPlayback": allowsInlineMediaPlayback,
+          "bounces": bounces,
+          "dataDetectorTypes":
+            UtilsRN.option_map(
+              dataDetectorType => {
+                let to_string =
+                  fun
+                  | `phoneNumber => "phoneNumber"
+                  | `link => "link"
+                  | `address => "address"
+                  | `calendarEvent => "calendarEvent"
+                  | `none => "none"
+                  | `all => "all";
+                dataDetectorType |> List.map(to_string) |> Array.of_list;
+              },
+              dataDetectorTypes,
+            ),
+          "decelerationRate":
+            UtilsRN.option_map(
+              rate => {
+                let to_float =
+                  fun
+                  | `normal => 0.998
+                  | `fast => 0.99
+                  | `value(f) => f;
+                rate |> List.map(to_float) |> Array.of_list;
+              },
+              decelerationRate,
+            ),
+          "onShouldStartLoadWithRequest": onShouldStartLoadWithRequest,
+          "scrollEnabled": scrollEnabled,
+        },
+      )
   );

--- a/src/private/props.re
+++ b/src/private/props.re
@@ -2,45 +2,34 @@ let serialize = (handlers: option(Types.touchResponderHandlers)) =>
   switch (handlers) {
   | None => Js.Obj.empty()
   | Some(handlers) =>
-    Js.Undefined.(
-      {
-        "onMoveShouldSetResponder":
-          fromOption(
-            UtilsRN.option_map(
-              (g, x) => g(x),
-              handlers.onMoveShouldSetResponder,
-            ),
-          ),
-        "onMoveShouldSetResponderCapture":
-          fromOption(
-            UtilsRN.option_map(
-              (g, x) => g(x),
-              handlers.onMoveShouldSetResponderCapture,
-            ),
-          ),
-        "onResponderGrant": fromOption(handlers.onResponderGrant),
-        "onResponderMove": fromOption(handlers.onResponderMove),
-        "onResponderReject": fromOption(handlers.onResponderReject),
-        "onResponderRelease": fromOption(handlers.onResponderRelease),
-        "onResponderTerminate": fromOption(handlers.onResponderTerminate),
-        "onResponderTerminationRequest":
-          fromOption(handlers.onResponderTerminationRequest),
-        "onStartShouldSetResponder":
-          fromOption(
-            UtilsRN.option_map(
-              (g, x) => g(x),
-              handlers.onStartShouldSetResponder,
-            ),
-          ),
-        "onStartShouldSetResponderCapture":
-          fromOption(
-            UtilsRN.option_map(
-              (g, x) => g(x),
-              handlers.onStartShouldSetResponderCapture,
-            ),
-          ),
-      }
-    )
+    {
+      "onMoveShouldSetResponder":
+        UtilsRN.option_map(
+          (g, x) => g(x),
+          handlers.onMoveShouldSetResponder,
+        ),
+      "onMoveShouldSetResponderCapture":
+        UtilsRN.option_map(
+          (g, x) => g(x),
+          handlers.onMoveShouldSetResponderCapture,
+        ),
+      "onResponderGrant": handlers.onResponderGrant,
+      "onResponderMove": handlers.onResponderMove,
+      "onResponderReject": handlers.onResponderReject,
+      "onResponderRelease": handlers.onResponderRelease,
+      "onResponderTerminate": handlers.onResponderTerminate,
+      "onResponderTerminationRequest": handlers.onResponderTerminationRequest,
+      "onStartShouldSetResponder":
+        UtilsRN.option_map(
+          (g, x) => g(x),
+          handlers.onStartShouldSetResponder,
+        ),
+      "onStartShouldSetResponderCapture":
+        UtilsRN.option_map(
+          (g, x) => g(x),
+          handlers.onStartShouldSetResponderCapture,
+        ),
+    }
   };
 
 let extendView =
@@ -68,115 +57,91 @@ let extendView =
       moreProps,
     ) =>
   UtilsRN.objAssign2(
-    Js.Undefined.(
-      {
-        "accessibilityLabel": fromOption(accessibilityLabel),
-        "accessible": fromOption(UtilsRN.optBoolToOptJsBoolean(accessible)),
-        "hitSlop": fromOption(hitSlop),
-        "onAccessibilityTap": fromOption(onAccessibilityTap),
-        "onLayout": fromOption(onLayout),
-        "onMagicTap": fromOption(onMagicTap),
-        "removeClippedSubviews":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(removeClippedSubviews)),
-        "pointerEvents":
-          fromOption(
-            UtilsRN.option_map(
-              x =>
-                switch (x) {
-                | `auto => "auto"
-                | `none => "none"
-                | `boxNone => "box-none"
-                | `boxOnly => "box-only"
-                },
-              pointerEvents,
-            ),
-          ),
-        "style": fromOption(style),
-        "testID": fromOption(testID),
-        "accessibilityComponentType":
-          fromOption(
-            UtilsRN.option_map(
-              x =>
-                switch (x) {
-                | `none => "none"
-                | `button => "button"
-                | `radiobutton_checked => "radiobutton_checked-none"
-                | `radiobutton_unchecked => "radiobutton_unchecked"
-                },
-              accessibilityComponentType,
-            ),
-          ),
-        "accessibilityLiveRegion":
-          fromOption(
-            UtilsRN.option_map(
-              x =>
-                switch (x) {
-                | `polite => "polite"
-                | `none => "none"
-                | `assertive => "assertive"
-                },
-              accessibilityLiveRegion,
-            ),
-          ),
-        "collapsable":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(collapsable)),
-        "importantForAccessibility":
-          fromOption(
-            UtilsRN.option_map(
-              prop =>
-                switch (prop) {
-                | `auto => "auto"
-                | `yes => "yes"
-                | `no => "no"
-                | `noHideDescendants => "noHideDescendants"
-                },
-              importantForAccessibility,
-            ),
-          ),
-        "needsOffscreenAlphaCompositing":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(needsOffscreenAlphaCompositing),
-          ),
-        "renderToHardwareTextureAndroid":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(renderToHardwareTextureAndroid),
-          ),
-        "accessibilityTraits":
-          fromOption(
-            UtilsRN.option_map(
-              traits => {
-                let to_string =
-                  fun
-                  | `none => "none"
-                  | `button => "button"
-                  | `link => "link"
-                  | `header => "header"
-                  | `search => "search"
-                  | `image => "image"
-                  | `selected => "selected"
-                  | `plays => "plays"
-                  | `key => "key"
-                  | `text => "text"
-                  | `summary => "summary"
-                  | `disabled => "disabled"
-                  | `frequentUpdates => "frequentUpdates"
-                  | `startsMedia => "startsMedia"
-                  | `adjustable => "adjustable"
-                  | `allowsDirectInteraction => "allowsDirectInteraction"
-                  | `pageTurn => "pageTurn";
-                traits |> List.map(to_string) |> Array.of_list;
-              },
-              accessibilityTraits,
-            ),
-          ),
-        "accessibilityViewIsModal":
-          fromOption(
-            UtilsRN.optBoolToOptJsBoolean(accessibilityViewIsModal),
-          ),
-        "shouldRasterizeIOS":
-          fromOption(UtilsRN.optBoolToOptJsBoolean(shouldRasterizeIOS)),
-      }
-    ),
+    {
+      "accessibilityLabel": accessibilityLabel,
+      "accessible": accessible,
+      "hitSlop": hitSlop,
+      "onAccessibilityTap": onAccessibilityTap,
+      "onLayout": onLayout,
+      "onMagicTap": onMagicTap,
+      "removeClippedSubviews": removeClippedSubviews,
+      "pointerEvents":
+        UtilsRN.option_map(
+          x =>
+            switch (x) {
+            | `auto => "auto"
+            | `none => "none"
+            | `boxNone => "box-none"
+            | `boxOnly => "box-only"
+            },
+          pointerEvents,
+        ),
+      "style": style,
+      "testID": testID,
+      "accessibilityComponentType":
+        UtilsRN.option_map(
+          x =>
+            switch (x) {
+            | `none => "none"
+            | `button => "button"
+            | `radiobutton_checked => "radiobutton_checked-none"
+            | `radiobutton_unchecked => "radiobutton_unchecked"
+            },
+          accessibilityComponentType,
+        ),
+      "accessibilityLiveRegion":
+        UtilsRN.option_map(
+          x =>
+            switch (x) {
+            | `polite => "polite"
+            | `none => "none"
+            | `assertive => "assertive"
+            },
+          accessibilityLiveRegion,
+        ),
+      "collapsable": collapsable,
+      "importantForAccessibility":
+        UtilsRN.option_map(
+          prop =>
+            switch (prop) {
+            | `auto => "auto"
+            | `yes => "yes"
+            | `no => "no"
+            | `noHideDescendants => "noHideDescendants"
+            },
+          importantForAccessibility,
+        ),
+      "needsOffscreenAlphaCompositing": needsOffscreenAlphaCompositing,
+      "renderToHardwareTextureAndroid": renderToHardwareTextureAndroid,
+      "accessibilityTraits":
+        UtilsRN.option_map(
+          traits => {
+            let to_string =
+              fun
+              | `none => "none"
+              | `button => "button"
+              | `link => "link"
+              | `header => "header"
+              | `search => "search"
+              | `image => "image"
+              | `selected => "selected"
+              | `plays => "plays"
+              | `key => "key"
+              | `text => "text"
+              | `summary => "summary"
+              | `disabled => "disabled"
+              | `frequentUpdates => "frequentUpdates"
+              | `startsMedia => "startsMedia"
+              | `adjustable => "adjustable"
+              | `allowsDirectInteraction => "allowsDirectInteraction"
+              | `pageTurn => "pageTurn";
+            traits |> List.map(to_string) |> Array.of_list;
+          },
+          accessibilityTraits,
+        ),
+      "accessibilityViewIsModal": accessibilityViewIsModal,
+      "shouldRasterizeIOS": shouldRasterizeIOS,
+    },
     moreProps,
     serialize(responderHandlers),
   );

--- a/src/private/utilsRN.re
+++ b/src/private/utilsRN.re
@@ -4,59 +4,8 @@ let option_map = (fn, opt_value) =>
   | Some(value) => Some(fn(value))
   };
 
-let optBoolToOptJsBoolean =
-  fun
-  | None => None
-  | Some(v) => Some(v);
-
 [@bs.val]
 external objAssign2 : (Js.t({..}), Js.t({..}), Js.t({..})) => Js.t({..}) =
   "Object.assign";
 
 let (<<) = (f, g, x) => f(g(x));
-
-/***
- * The following is taken from bs-json (https://github.com/BuckleTypes/bs-json) converted to reason syntax
- */
-let dictEntries = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    let key = Array.unsafe_get(keys, i);
-    values[i] = (key, Js.Dict.unsafeGet(dict, key));
-  };
-  values;
-}; /* external values : 'a t -> 'a array = "Object.values" [@@bs.val] (* ES2017 *) */
-
-let dictValues = dict => {
-  let keys = Js.Dict.keys(dict);
-  let l = Js.Array.length(keys);
-  let values = Obj.magic(Array.make(l, 0));
-  for (i in 0 to l - 1) {
-    values[i] = Js.Dict.unsafeGet(dict, Array.unsafe_get(keys, i));
-  };
-  values;
-};
-
-let dictFromList = entries => {
-  let dict = Js.Dict.empty();
-  let rec loop =
-    fun
-    | [] => dict
-    | [(key, value), ...rest] => {
-        Js.Dict.set(dict, key, value);
-        loop(rest);
-      };
-  loop(entries);
-};
-
-let dictFromArray = entries => {
-  let dict = Js.Dict.empty();
-  let l = Js_array.length(entries);
-  for (i in 0 to l - 1) {
-    let (key, value) = Array.unsafe_get(entries, i);
-    Js.Dict.set(dict, key, value);
-  };
-  dict;
-};

--- a/src/style.re
+++ b/src/style.re
@@ -70,10 +70,10 @@ external array_to_style : array(t) => t = "%identity";
 let combine = (a, b) => {
   let entries =
     Array.append(
-      UtilsRN.dictEntries(style_to_dict(a)),
-      UtilsRN.dictEntries(style_to_dict(b)),
+      Js.Dict.entries(style_to_dict(a)),
+      Js.Dict.entries(style_to_dict(b)),
     );
-  UtilsRN.dictFromArray(entries) |> to_style;
+  Js.Dict.fromArray(entries) |> to_style;
 };
 
 let concat = styles => array_to_style(Array.of_list(styles));
@@ -86,7 +86,7 @@ let objectStyle = (key, value) => (key, Encode.object_(value));
 
 let arrayStyle = (key, value) => (key, Encode.array(value));
 
-let style = sarr => sarr |> UtilsRN.dictFromList |> to_style;
+let style = sarr => sarr |> Js.Dict.fromList |> to_style;
 
 /***
  * Layout Props
@@ -339,7 +339,7 @@ let shadowColor = value => (
 );
 
 let shadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])
@@ -385,7 +385,7 @@ module Transform = {
           switch (x) {
           | (key, Some(value)) =>
             let val_ =
-              UtilsRN.dictFromArray([|(key, value)|]) |> Encode.object_;
+              Js.Dict.fromArray([|(key, value)|]) |> Encode.object_;
             [val_, ...acc];
           | _ => acc
           },
@@ -651,7 +651,7 @@ let textShadowColor = value => (
 );
 
 let textShadowOffset = (~height, ~width) =>
-  UtilsRN.dictFromArray([|
+  Js.Dict.fromArray([|
     ("height", Encode.float(height)),
     ("width", Encode.float(width)),
   |])


### PR DESCRIPTION
Removed `bool-Js.boolean` conversion artifacts (calls to `UtilsRN.optBoolToOptJsBoolean` which became redundant).
Removed a lot of calls to `Js.Undefined.fromOption`
Removed references to functions in `utilsRN.re` duplicating BuckleScript standard library.

This PR includes changes from two previous PRs.
