### PR TITLE
Release v0.10.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bs-react-native",
-	"version": "0.9.0",
+	"version": "0.10.0-rc.0",
 	"scripts": {
 		"build": "bsb -make-world",
 		"start": "bsb -make-world -w",


### PR DESCRIPTION
Can't make a direct push, so making a PR. 

Pushed 0.10.0-rc.0 and tagged it as `next`. We will use this one to test `Rebolt` integration and many new features before promoting it to stable (similar to React Native lifecycle).