### PR TITLE
Improve `Style` bindings with `Animated`

### DIFF
--- a/lib/js/src/components/flatList.js
+++ b/lib/js/src/components/flatList.js
@@ -33,7 +33,7 @@ function CreateComponent(Impl) {
     return /* () */0;
   };
   var scrollToOffset = function (ref, offset, animated, _) {
-    ref._scrollToIndex({
+    ref.scrollToOffset({
           offset: Js_undefined.fromOption(offset),
           animated: Js_undefined.fromOption(animated)
         });
@@ -142,7 +142,7 @@ function scrollToItem(ref, item, animated, viewPosition, _) {
 }
 
 function scrollToOffset(ref, offset, animated, _) {
-  ref._scrollToIndex({
+  ref.scrollToOffset({
         offset: Js_undefined.fromOption(offset),
         animated: Js_undefined.fromOption(animated)
       });

--- a/lib/js/src/style.js
+++ b/lib/js/src/style.js
@@ -609,18 +609,6 @@ function makeAnimated(perspective, rotate, rotateX, rotateY, rotateZ, scaleX, sc
               }), perspective, rotate, rotateX, rotateY, rotateZ, scaleX, scaleY, translateX, translateY, skewX, skewY);
 }
 
-function makeInterpolated(perspective, rotate, rotateX, rotateY, rotateZ, scaleX, scaleY, translateX, translateY, skewX, skewY, _) {
-  return create_((function (value) {
-                return UtilsRN$BsReactNative.option_map((function (prim) {
-                              return prim;
-                            }), value);
-              }), (function (value) {
-                return UtilsRN$BsReactNative.option_map((function (prim) {
-                              return prim;
-                            }), value);
-              }), perspective, rotate, rotateX, rotateY, rotateZ, scaleX, scaleY, translateX, translateY, skewX, skewY);
-}
-
 function backfaceVisibility(v) {
   return /* tuple */[
           "backfaceVisibility",
@@ -1020,8 +1008,7 @@ function flatten(prim) {
 
 var Transform = [
   make,
-  makeAnimated,
-  makeInterpolated
+  makeAnimated
 ];
 
 exports.style = style;

--- a/lib/js/src/style.js
+++ b/lib/js/src/style.js
@@ -25,11 +25,14 @@ function encode_pt_pct_auto(value) {
   }
 }
 
-function encode_pt_pct_animated_interpolated(param) {
-  if (param.tag === 1) {
-    return Encode$BsReactNative.pct(param[0]);
-  } else {
-    return param[0];
+function encode_pt_pct_animated(param) {
+  switch (param.tag | 0) {
+    case 1 : 
+        return Encode$BsReactNative.pct(param[0]);
+    case 0 : 
+    case 2 : 
+        return param[0];
+    
   }
 }
 
@@ -414,42 +417,42 @@ function position(v) {
 function top(value) {
   return /* tuple */[
           "top",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
 function left(value) {
   return /* tuple */[
           "left",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
 function right(value) {
   return /* tuple */[
           "right",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
 function bottom(value) {
   return /* tuple */[
           "bottom",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
 function height(value) {
   return /* tuple */[
           "height",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
 function width(value) {
   return /* tuple */[
           "width",
-          encode_pt_pct_animated_interpolated(value)
+          encode_pt_pct_animated(value)
         ];
 }
 
@@ -1002,19 +1005,14 @@ function overlayColor(value) {
         ];
 }
 
-function flatten(prim) {
-  return prim;
-}
-
 var Transform = [
   make,
   makeAnimated
 ];
 
-exports.style = style;
-exports.flatten = flatten;
 exports.combine = combine;
 exports.concat = concat;
+exports.style = style;
 exports.alignContent = alignContent;
 exports.alignItems = alignItems;
 exports.alignSelf = alignSelf;
@@ -1024,11 +1022,11 @@ exports.borderLeftWidth = borderLeftWidth;
 exports.borderRightWidth = borderRightWidth;
 exports.borderTopWidth = borderTopWidth;
 exports.borderWidth = borderWidth;
-exports.flex = flex;
 exports.display = display;
+exports.flex = flex;
 exports.flexBasis = flexBasis;
-exports.flexGrow = flexGrow;
 exports.flexDirection = flexDirection;
+exports.flexGrow = flexGrow;
 exports.flexShrink = flexShrink;
 exports.flexWrap = flexWrap;
 exports.justifyContent = justifyContent;
@@ -1075,9 +1073,9 @@ exports.borderLeftColor = borderLeftColor;
 exports.borderRadius = borderRadius;
 exports.borderTopLeftRadius = borderTopLeftRadius;
 exports.borderTopRightRadius = borderTopRightRadius;
-exports.borderStyle = borderStyle;
 exports.borderBottomLeftRadius = borderBottomLeftRadius;
 exports.borderBottomRightRadius = borderBottomRightRadius;
+exports.borderStyle = borderStyle;
 exports.opacity = opacity;
 exports.elevation = elevation;
 exports.color = color;

--- a/src/private/encode.re
+++ b/src/private/encode.re
@@ -15,9 +15,6 @@ external object_ : Js_dict.t(Js.Json.t) => Js.Json.t = "%identity"; /* [object_ 
 
 external array : array(Js.Json.t) => Js.Json.t = "%identity";
 
-external animatedValue : AnimatedRe.Value.t => Js.Json.t = "%identity";
-
-external interpolatedValue : AnimatedRe.Interpolation.t => Js.Json.t =
-  "%identity";
+external animatedValue : AnimatedRe.value('a) => Js.Json.t = "%identity";
 
 let pct = pct => string(Printf.sprintf("%.2f%%", pct));

--- a/src/style.re
+++ b/src/style.re
@@ -26,38 +26,34 @@ let encode_pt_pct_auto = value =>
   | Auto => Encode.string("auto")
   };
 
-type pt_pct_animated_interpolated =
+type pt_pct_animated('a) =
   | Pt(float)
   | Pct(float)
-  | Animated(AnimatedRe.Value.t)
-  | Interpolated(AnimatedRe.Interpolation.t);
+  | Animated(AnimatedRe.value('a));
 
-let encode_pt_pct_animated_interpolated =
+let encode_pt_pct_animated =
   fun
   | Pt(value) => Encode.float(value)
   | Pct(value) => Encode.pct(value)
-  | Animated(value) => Encode.animatedValue(value)
-  | Interpolated(value) => Encode.animatedValue(value);
+  | Animated(value) => Encode.animatedValue(value);
 
-type float_interpolated_animated =
+type float_animated('a) =
   | Float(float)
-  | Animated(AnimatedRe.Value.t)
-  | Interpolated(AnimatedRe.Interpolation.t);
+  | Animated(AnimatedRe.value('a));
 
-let encode_float_interpolated_animated =
+let encode_float_animated =
   fun
   | Float(value) => Encode.float(value)
-  | Animated(value) => Encode.animatedValue(value)
-  | Interpolated(value) => Encode.animatedValue(value);
+  | Animated(value) => Encode.animatedValue(value);
 
-type string_interpolated =
+type string_animated('a) =
   | String(string)
-  | Interpolated(AnimatedRe.Interpolation.t);
+  | Animated(AnimatedRe.value('a));
 
-let encode_string_interpolated =
+let encode_string_animated =
   fun
   | String(value) => Encode.string(value)
-  | Interpolated(value) => Encode.animatedValue(value);
+  | Animated(value) => Encode.animatedValue(value);
 
 external flatten : array(t) => t = "%identity";
 
@@ -301,17 +297,17 @@ let position = v =>
     },
   );
 
-let top = value => ("top", encode_pt_pct_animated_interpolated(value));
+let top = value => ("top", encode_pt_pct_animated(value));
 
-let left = value => ("left", encode_pt_pct_animated_interpolated(value));
+let left = value => ("left", encode_pt_pct_animated(value));
 
-let right = value => ("right", encode_pt_pct_animated_interpolated(value));
+let right = value => ("right", encode_pt_pct_animated(value));
 
-let bottom = value => ("bottom", encode_pt_pct_animated_interpolated(value));
+let bottom = value => ("bottom", encode_pt_pct_animated(value));
 
-let height = value => ("height", encode_pt_pct_animated_interpolated(value));
+let height = value => ("height", encode_pt_pct_animated(value));
 
-let width = value => ("width", encode_pt_pct_animated_interpolated(value));
+let width = value => ("width", encode_pt_pct_animated(value));
 
 let zIndex = value => ("zIndex", Encode.int(value));
 
@@ -335,7 +331,7 @@ let direction = v =>
  */
 let shadowColor = value => (
   "shadowColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let shadowOffset = (~height, ~width) =>
@@ -474,32 +470,32 @@ let backfaceVisibility = v =>
 
 let backgroundColor = value => (
   "backgroundColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderColor = value => (
   "borderColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderTopColor = value => (
   "borderTopColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderRightColor = value => (
   "borderRightColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderBottomColor = value => (
   "borderBottomColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderLeftColor = value => (
   "borderLeftColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let borderRadius = floatStyle("borderRadius");
@@ -529,7 +525,7 @@ let borderStyle = v =>
 
 let opacity = value => (
   "opacity",
-  encode_float_interpolated_animated(value),
+  encode_float_animated(value),
 );
 
 let elevation = floatStyle("elevation");
@@ -537,13 +533,13 @@ let elevation = floatStyle("elevation");
 /***
  * Text Props
  */
-let color = value => ("color", encode_string_interpolated(value));
+let color = value => ("color", encode_string_animated(value));
 
 let fontFamily = stringStyle("fontFamily");
 
 let fontSize = value => (
   "fontSize",
-  encode_float_interpolated_animated(value),
+  encode_float_animated(value),
 );
 
 type fontStyle =
@@ -617,7 +613,7 @@ let textDecorationLine = v =>
 
 let textShadowColor = value => (
   "textShadowColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 let textShadowOffset = (~height, ~width) =>
@@ -661,7 +657,7 @@ let letterSpacing = floatStyle("letterSpacing");
 
 let textDecorationColor = value => (
   "textDecorationColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 type textDecorationStyle =
@@ -716,11 +712,11 @@ let resizeMode = v =>
     },
   );
 
-let tintColor = value => ("tintColor", encode_string_interpolated(value));
+let tintColor = value => ("tintColor", encode_string_animated(value));
 
 let overlayColor = value => (
   "overlayColor",
-  encode_string_interpolated(value),
+  encode_string_animated(value),
 );
 
 type color =

--- a/src/style.re
+++ b/src/style.re
@@ -37,7 +37,7 @@ let encode_pt_pct_animated_interpolated =
   | Pt(value) => Encode.float(value)
   | Pct(value) => Encode.pct(value)
   | Animated(value) => Encode.animatedValue(value)
-  | Interpolated(value) => Encode.interpolatedValue(value);
+  | Interpolated(value) => Encode.animatedValue(value);
 
 type float_interpolated_animated =
   | Float(float)
@@ -48,7 +48,7 @@ let encode_float_interpolated_animated =
   fun
   | Float(value) => Encode.float(value)
   | Animated(value) => Encode.animatedValue(value)
-  | Interpolated(value) => Encode.interpolatedValue(value);
+  | Interpolated(value) => Encode.animatedValue(value);
 
 type string_interpolated =
   | String(string)
@@ -57,7 +57,7 @@ type string_interpolated =
 let encode_string_interpolated =
   fun
   | String(value) => Encode.string(value)
-  | Interpolated(value) => Encode.interpolatedValue(value);
+  | Interpolated(value) => Encode.animatedValue(value);
 
 external flatten : array(t) => t = "%identity";
 
@@ -442,36 +442,6 @@ module Transform = {
     create_(
       (. value) => UtilsRN.option_map(Encode.animatedValue, value),
       (. value) => UtilsRN.option_map(Encode.animatedValue, value),
-      perspective,
-      rotate,
-      rotateX,
-      rotateY,
-      rotateZ,
-      scaleX,
-      scaleY,
-      translateX,
-      translateY,
-      skewX,
-      skewY,
-    );
-  let makeInterpolated =
-      (
-        ~perspective=?,
-        ~rotate=?,
-        ~rotateX=?,
-        ~rotateY=?,
-        ~rotateZ=?,
-        ~scaleX=?,
-        ~scaleY=?,
-        ~translateX=?,
-        ~translateY=?,
-        ~skewX=?,
-        ~skewY=?,
-        (),
-      ) =>
-    create_(
-      (. value) => UtilsRN.option_map(Encode.interpolatedValue, value),
-      (. value) => UtilsRN.option_map(Encode.interpolatedValue, value),
       perspective,
       rotate,
       rotateX,

--- a/src/style.re
+++ b/src/style.re
@@ -46,11 +46,11 @@ let encode_float_animated =
   | Float(value) => Encode.float(value)
   | Animated(value) => Encode.animatedValue(value);
 
-type string_animated('a) =
+type string_interpolated =
   | String(string)
-  | Animated(AnimatedRe.value('a));
+  | Animated(AnimatedRe.Interpolation.t);
 
-let encode_string_animated =
+let encode_string_interpolated =
   fun
   | String(value) => Encode.string(value)
   | Animated(value) => Encode.animatedValue(value);
@@ -331,7 +331,7 @@ let direction = v =>
  */
 let shadowColor = value => (
   "shadowColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let shadowOffset = (~height, ~width) =>
@@ -470,32 +470,32 @@ let backfaceVisibility = v =>
 
 let backgroundColor = value => (
   "backgroundColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderColor = value => (
   "borderColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderTopColor = value => (
   "borderTopColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderRightColor = value => (
   "borderRightColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderBottomColor = value => (
   "borderBottomColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderLeftColor = value => (
   "borderLeftColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let borderRadius = floatStyle("borderRadius");
@@ -533,7 +533,7 @@ let elevation = floatStyle("elevation");
 /***
  * Text Props
  */
-let color = value => ("color", encode_string_animated(value));
+let color = value => ("color", encode_string_interpolated(value));
 
 let fontFamily = stringStyle("fontFamily");
 
@@ -613,7 +613,7 @@ let textDecorationLine = v =>
 
 let textShadowColor = value => (
   "textShadowColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 let textShadowOffset = (~height, ~width) =>
@@ -657,7 +657,7 @@ let letterSpacing = floatStyle("letterSpacing");
 
 let textDecorationColor = value => (
   "textDecorationColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 type textDecorationStyle =
@@ -712,11 +712,11 @@ let resizeMode = v =>
     },
   );
 
-let tintColor = value => ("tintColor", encode_string_animated(value));
+let tintColor = value => ("tintColor", encode_string_interpolated(value));
 
 let overlayColor = value => (
   "overlayColor",
-  encode_string_animated(value),
+  encode_string_interpolated(value),
 );
 
 type color =

--- a/src/style.rei
+++ b/src/style.rei
@@ -16,9 +16,9 @@ type pt_pct_animated('a) =
 type float_animated('a) =
   | Float(float)
   | Animated(AnimatedRe.value('a));
-type string_animated('a) =
+type string_interpolated =
   | String(string)
-  | Animated(AnimatedRe.value('a));
+  | Animated(AnimatedRe.Interpolation.t);
 external flatten : array(t) => t = "%identity";
 let combine: (t, t) => t;
 let concat: list(t) => t;
@@ -116,7 +116,7 @@ type direction =
   | Ltr
   | Rtl;
 let direction: direction => styleElement;
-let shadowColor: string_animated('a) => styleElement;
+let shadowColor: string_interpolated => styleElement;
 let shadowOffset: (~height: float, ~width: float) => styleElement;
 let shadowOpacity: float => styleElement;
 let shadowRadius: float => styleElement;
@@ -158,12 +158,12 @@ type backfaceVisibility =
   | Visible
   | Hidden;
 let backfaceVisibility: backfaceVisibility => styleElement;
-let backgroundColor: string_animated('a) => styleElement;
-let borderColor: string_animated('a) => styleElement;
-let borderTopColor: string_animated('a) => styleElement;
-let borderRightColor: string_animated('a) => styleElement;
-let borderBottomColor: string_animated('a) => styleElement;
-let borderLeftColor: string_animated('a) => styleElement;
+let backgroundColor: string_interpolated => styleElement;
+let borderColor: string_interpolated => styleElement;
+let borderTopColor: string_interpolated => styleElement;
+let borderRightColor: string_interpolated => styleElement;
+let borderBottomColor: string_interpolated => styleElement;
+let borderLeftColor: string_interpolated => styleElement;
 let borderRadius: float => styleElement;
 let borderTopLeftRadius: float => styleElement;
 let borderTopRightRadius: float => styleElement;
@@ -176,7 +176,7 @@ type borderStyle =
 let borderStyle: borderStyle => styleElement;
 let opacity: float_animated('a) => styleElement;
 let elevation: float => styleElement;
-let color: string_animated('a) => styleElement;
+let color: string_interpolated => styleElement;
 let fontFamily: string => styleElement;
 let fontSize: float_animated('a) => styleElement;
 type fontStyle =
@@ -212,7 +212,7 @@ type textDecorationLine =
   | LineThrough
   | UnderlineLineThrough;
 let textDecorationLine: textDecorationLine => styleElement;
-let textShadowColor: string_animated('a) => styleElement;
+let textShadowColor: string_interpolated => styleElement;
 let textShadowOffset: (~height: float, ~width: float) => styleElement;
 let textShadowRadius: float => styleElement;
 let includeFontPadding: bool => styleElement;
@@ -224,7 +224,7 @@ type textAlignVertical =
 let textAlignVertical: textAlignVertical => styleElement;
 let fontVariant: list(string) => styleElement;
 let letterSpacing: float => styleElement;
-let textDecorationColor: string_animated('a) => styleElement;
+let textDecorationColor: string_interpolated => styleElement;
 type textDecorationStyle =
   | Solid
   | Double
@@ -243,7 +243,7 @@ type resizeMode =
   | Repeat
   | Center;
 let resizeMode: resizeMode => styleElement;
-let tintColor: string_animated('a) =>  styleElement;
-let overlayColor: string_animated('a) => styleElement;
+let tintColor: string_interpolated =>  styleElement;
+let overlayColor: string_interpolated => styleElement;
 type color =
   | String(string);

--- a/src/style.rei
+++ b/src/style.rei
@@ -1,52 +1,28 @@
 type t;
-
 type styleElement;
-
 type pt_only =
   | Pt(float);
-
 type pt_pct =
   | Pt(float)
   | Pct(float);
-
 type pt_pct_auto =
   | Pt(float)
   | Pct(float)
   | Auto;
-
-type pt_pct_animated_interpolated =
+type pt_pct_animated('a) =
   | Pt(float)
   | Pct(float)
-  | Animated(AnimatedRe.Value.t)
-  | Interpolated(AnimatedRe.Interpolation.t);
-
-type float_interpolated_animated =
+  | Animated(BsReactNative.AnimatedRe.value('a));
+type float_animated('a) =
   | Float(float)
-  | Animated(AnimatedRe.Value.t)
-  | Interpolated(AnimatedRe.Interpolation.t);
-
-type string_interpolated =
+  | Animated(BsReactNative.AnimatedRe.value('a));
+type string_animated('a) =
   | String(string)
-  | Interpolated(AnimatedRe.Interpolation.t);
-
-let style: list(styleElement) => t;
-
-/*** Generates a style out of an array of styles.
-  * This is equivalent:
-  * // js
-  * <View style={[styleA, styleB]} />
-  * // reason
-  * <View style=(Style.flatten [|styleA, styleB|]) />
- */
-let flatten: array(t) => t;
-
+  | Animated(BsReactNative.AnimatedRe.value('a));
+external flatten : array(t) => t = "%identity";
 let combine: (t, t) => t;
-
 let concat: list(t) => t;
-
-/***
- * Layout Props
- */
+let style: list(styleElement) => t;
 type alignContent =
   | FlexStart
   | FlexEnd
@@ -54,67 +30,45 @@ type alignContent =
   | Stretch
   | SpaceAround
   | SpaceBetween;
-
 let alignContent: alignContent => styleElement;
-
 type alignItems =
   | FlexStart
   | FlexEnd
   | Center
   | Stretch
   | Baseline;
-
 let alignItems: alignItems => styleElement;
-
 type alignSelf =
   | FlexStart
   | FlexEnd
   | Center
   | Stretch
   | Baseline;
-
 let alignSelf: alignSelf => styleElement;
-
 let aspectRatio: float => styleElement;
-
 let borderBottomWidth: float => styleElement;
-
 let borderLeftWidth: float => styleElement;
-
 let borderRightWidth: float => styleElement;
-
 let borderTopWidth: float => styleElement;
-
 let borderWidth: float => styleElement;
-
-let flex: float => styleElement;
-
 type display =
   | Flex
   | None;
-
 let display: display => styleElement;
-
+let flex: float => styleElement;
 let flexBasis: pt_pct => styleElement;
-
-let flexGrow: float => styleElement;
-
 type flexDirection =
   | Row
   | RowReverse
   | Column
   | ColumnReverse;
-
 let flexDirection: flexDirection => styleElement;
-
+let flexGrow: float => styleElement;
 let flexShrink: float => styleElement;
-
 type flexWrap =
   | Wrap
   | Nowrap;
-
 let flexWrap: flexWrap => styleElement;
-
 type justifyContent =
   | FlexStart
   | FlexEnd
@@ -122,90 +76,50 @@ type justifyContent =
   | Stretch
   | SpaceAround
   | SpaceBetween;
-
 let justifyContent: justifyContent => styleElement;
-
 let margin: pt_pct_auto => styleElement;
-
 let marginBottom: pt_pct_auto => styleElement;
-
 let marginHorizontal: pt_pct_auto => styleElement;
-
 let marginLeft: pt_pct_auto => styleElement;
-
 let marginRight: pt_pct_auto => styleElement;
-
 let marginTop: pt_pct_auto => styleElement;
-
 let marginVertical: pt_pct_auto => styleElement;
-
 let maxHeight: pt_pct => styleElement;
-
 let maxWidth: pt_pct => styleElement;
-
 let minHeight: pt_pct => styleElement;
-
 let minWidth: pt_pct => styleElement;
-
 type overflow =
   | Visible
   | Hidden
   | Scroll;
-
 let overflow: overflow => styleElement;
-
 let padding: pt_pct => styleElement;
-
 let paddingBottom: pt_pct => styleElement;
-
 let paddingHorizontal: pt_pct => styleElement;
-
 let paddingLeft: pt_pct => styleElement;
-
 let paddingRight: pt_pct => styleElement;
-
 let paddingTop: pt_pct => styleElement;
-
 let paddingVertical: pt_pct => styleElement;
-
 type position =
   | Absolute
   | Relative;
-
 let position: position => styleElement;
-
-let top: pt_pct_animated_interpolated => styleElement;
-
-let left: pt_pct_animated_interpolated => styleElement;
-
-let right: pt_pct_animated_interpolated => styleElement;
-
-let bottom: pt_pct_animated_interpolated => styleElement;
-
-let height: pt_pct_animated_interpolated => styleElement;
-
-let width: pt_pct_animated_interpolated => styleElement;
-
+let top: pt_pct_animated('a) => styleElement;
+let left: pt_pct_animated('a) => styleElement;
+let right: pt_pct_animated('a) => styleElement;
+let bottom: pt_pct_animated('a) => styleElement;
+let height: pt_pct_animated('a) => styleElement;
+let width: pt_pct_animated('a) => styleElement;
 let zIndex: int => styleElement;
-
 type direction =
   | Inherit
   | Ltr
   | Rtl;
-
 let direction: direction => styleElement;
-
-/***
- * Shadow Props
- */
-let shadowColor: string_interpolated => styleElement;
-
+let shadowColor: string_animated('a) => styleElement;
 let shadowOffset: (~height: float, ~width: float) => styleElement;
-
 let shadowOpacity: float => styleElement;
-
 let shadowRadius: float => styleElement;
-
 module Transform: {
   let make:
     (
@@ -225,83 +139,54 @@ module Transform: {
     styleElement;
   let makeAnimated:
     (
-      ~perspective: AnimatedRe.value('a)=?,
-      ~rotate: AnimatedRe.value('a)=?,
-      ~rotateX: AnimatedRe.value('a)=?,
-      ~rotateY: AnimatedRe.value('a)=?,
-      ~rotateZ: AnimatedRe.value('a)=?,
-      ~scaleX: AnimatedRe.value('a)=?,
-      ~scaleY: AnimatedRe.value('a)=?,
-      ~translateX: AnimatedRe.value('a)=?,
-      ~translateY: AnimatedRe.value('a)=?,
-      ~skewX: AnimatedRe.value('a)=?,
-      ~skewY: AnimatedRe.value('a)=?,
+      ~perspective: BsReactNative.AnimatedRe.value('a)=?,
+      ~rotate: BsReactNative.AnimatedRe.value('a)=?,
+      ~rotateX: BsReactNative.AnimatedRe.value('a)=?,
+      ~rotateY: BsReactNative.AnimatedRe.value('a)=?,
+      ~rotateZ: BsReactNative.AnimatedRe.value('a)=?,
+      ~scaleX: BsReactNative.AnimatedRe.value('a)=?,
+      ~scaleY: BsReactNative.AnimatedRe.value('a)=?,
+      ~translateX: BsReactNative.AnimatedRe.value('a)=?,
+      ~translateY: BsReactNative.AnimatedRe.value('a)=?,
+      ~skewX: BsReactNative.AnimatedRe.value('a)=?,
+      ~skewY: BsReactNative.AnimatedRe.value('a)=?,
       unit
     ) =>
     styleElement;
 };
-
-/***
- * View Props
- */
 type backfaceVisibility =
   | Visible
   | Hidden;
-
 let backfaceVisibility: backfaceVisibility => styleElement;
-
-let backgroundColor: string_interpolated => styleElement;
-
-let borderColor: string_interpolated => styleElement;
-
-let borderTopColor: string_interpolated => styleElement;
-
-let borderRightColor: string_interpolated => styleElement;
-
-let borderBottomColor: string_interpolated => styleElement;
-
-let borderLeftColor: string_interpolated => styleElement;
-
+let backgroundColor: string_animated('a) => styleElement;
+let borderColor: string_animated('a) => styleElement;
+let borderTopColor: string_animated('a) => styleElement;
+let borderRightColor: string_animated('a) => styleElement;
+let borderBottomColor: string_animated('a) => styleElement;
+let borderLeftColor: string_animated('a) => styleElement;
 let borderRadius: float => styleElement;
-
 let borderTopLeftRadius: float => styleElement;
-
 let borderTopRightRadius: float => styleElement;
-
+let borderBottomLeftRadius: float => styleElement;
+let borderBottomRightRadius: float => styleElement;
 type borderStyle =
   | Solid
   | Dotted
   | Dashed;
-
 let borderStyle: borderStyle => styleElement;
-
-let borderBottomLeftRadius: float => styleElement;
-
-let borderBottomRightRadius: float => styleElement;
-
-let opacity: float_interpolated_animated => styleElement;
-
+let opacity: float_animated('a) => styleElement;
 let elevation: float => styleElement;
-
-/***
- *  Text Props
- */
-let color: string_interpolated => styleElement;
-
+let color: string_animated('a) => styleElement;
 let fontFamily: string => styleElement;
-
-let fontSize: float_interpolated_animated => styleElement;
-
+let fontSize: float_animated('a) => styleElement;
 type fontStyle =
   | Normal
   | Italic;
-
 let fontStyle: fontStyle => styleElement;
-
 let fontWeight:
-  [
-    | `Normal
+  [<
     | `Bold
+    | `Normal
     | `_100
     | `_200
     | `_300
@@ -313,75 +198,52 @@ let fontWeight:
     | `_900
   ] =>
   styleElement;
-
 let lineHeight: float => styleElement;
-
 type textAlign =
   | Auto
   | Left
   | Right
   | Center
   | Justify;
-
 let textAlign: textAlign => styleElement;
-
 type textDecorationLine =
   | None
   | Underline
   | LineThrough
   | UnderlineLineThrough;
-
 let textDecorationLine: textDecorationLine => styleElement;
-
-let textShadowColor: string_interpolated => styleElement;
-
+let textShadowColor: string_animated('a) => styleElement;
 let textShadowOffset: (~height: float, ~width: float) => styleElement;
-
 let textShadowRadius: float => styleElement;
-
 let includeFontPadding: bool => styleElement;
-
 type textAlignVertical =
   | Auto
   | Top
   | Bottom
   | Center;
-
 let textAlignVertical: textAlignVertical => styleElement;
-
 let fontVariant: list(string) => styleElement;
-
 let letterSpacing: float => styleElement;
-
-let textDecorationColor: string_interpolated => styleElement;
-
+let textDecorationColor: string_animated('a) => styleElement;
 type textDecorationStyle =
   | Solid
   | Double
   | Dotted
   | Dashed;
-
 let textDecorationStyle: textDecorationStyle => styleElement;
-
 type writingDirection =
   | Auto
   | Ltr
   | Rtl;
-
 let writingDirection: writingDirection => styleElement;
-
 type resizeMode =
   | Cover
   | Contain
   | Stretch
   | Repeat
   | Center;
-
 let resizeMode: resizeMode => styleElement;
-
-let tintColor: string_interpolated => styleElement;
-
-let overlayColor: string_interpolated => styleElement;
-
+let tintColor: string_animated('a) =>  styleElement;
+let overlayColor: string_animated('a) => styleElement;
 type color =
   | String(string);

--- a/src/style.rei
+++ b/src/style.rei
@@ -12,13 +12,13 @@ type pt_pct_auto =
 type pt_pct_animated('a) =
   | Pt(float)
   | Pct(float)
-  | Animated(BsReactNative.AnimatedRe.value('a));
+  | Animated(AnimatedRe.value('a));
 type float_animated('a) =
   | Float(float)
-  | Animated(BsReactNative.AnimatedRe.value('a));
+  | Animated(AnimatedRe.value('a));
 type string_animated('a) =
   | String(string)
-  | Animated(BsReactNative.AnimatedRe.value('a));
+  | Animated(AnimatedRe.value('a));
 external flatten : array(t) => t = "%identity";
 let combine: (t, t) => t;
 let concat: list(t) => t;
@@ -139,17 +139,17 @@ module Transform: {
     styleElement;
   let makeAnimated:
     (
-      ~perspective: BsReactNative.AnimatedRe.value('a)=?,
-      ~rotate: BsReactNative.AnimatedRe.value('a)=?,
-      ~rotateX: BsReactNative.AnimatedRe.value('a)=?,
-      ~rotateY: BsReactNative.AnimatedRe.value('a)=?,
-      ~rotateZ: BsReactNative.AnimatedRe.value('a)=?,
-      ~scaleX: BsReactNative.AnimatedRe.value('a)=?,
-      ~scaleY: BsReactNative.AnimatedRe.value('a)=?,
-      ~translateX: BsReactNative.AnimatedRe.value('a)=?,
-      ~translateY: BsReactNative.AnimatedRe.value('a)=?,
-      ~skewX: BsReactNative.AnimatedRe.value('a)=?,
-      ~skewY: BsReactNative.AnimatedRe.value('a)=?,
+      ~perspective: AnimatedRe.value('a)=?,
+      ~rotate: AnimatedRe.value('a)=?,
+      ~rotateX: AnimatedRe.value('a)=?,
+      ~rotateY: AnimatedRe.value('a)=?,
+      ~rotateZ: AnimatedRe.value('a)=?,
+      ~scaleX: AnimatedRe.value('a)=?,
+      ~scaleY: AnimatedRe.value('a)=?,
+      ~translateX: AnimatedRe.value('a)=?,
+      ~translateY: AnimatedRe.value('a)=?,
+      ~skewX: AnimatedRe.value('a)=?,
+      ~skewY: AnimatedRe.value('a)=?,
       unit
     ) =>
     styleElement;

--- a/src/style.rei
+++ b/src/style.rei
@@ -225,33 +225,17 @@ module Transform: {
     styleElement;
   let makeAnimated:
     (
-      ~perspective: AnimatedRe.Value.t=?,
-      ~rotate: AnimatedRe.Value.t=?,
-      ~rotateX: AnimatedRe.Value.t=?,
-      ~rotateY: AnimatedRe.Value.t=?,
-      ~rotateZ: AnimatedRe.Value.t=?,
-      ~scaleX: AnimatedRe.Value.t=?,
-      ~scaleY: AnimatedRe.Value.t=?,
-      ~translateX: AnimatedRe.Value.t=?,
-      ~translateY: AnimatedRe.Value.t=?,
-      ~skewX: AnimatedRe.Value.t=?,
-      ~skewY: AnimatedRe.Value.t=?,
-      unit
-    ) =>
-    styleElement;
-  let makeInterpolated:
-    (
-      ~perspective: AnimatedRe.Interpolation.t=?,
-      ~rotate: AnimatedRe.Interpolation.t=?,
-      ~rotateX: AnimatedRe.Interpolation.t=?,
-      ~rotateY: AnimatedRe.Interpolation.t=?,
-      ~rotateZ: AnimatedRe.Interpolation.t=?,
-      ~scaleX: AnimatedRe.Interpolation.t=?,
-      ~scaleY: AnimatedRe.Interpolation.t=?,
-      ~translateX: AnimatedRe.Interpolation.t=?,
-      ~translateY: AnimatedRe.Interpolation.t=?,
-      ~skewX: AnimatedRe.Interpolation.t=?,
-      ~skewY: AnimatedRe.Interpolation.t=?,
+      ~perspective: AnimatedRe.value('a)=?,
+      ~rotate: AnimatedRe.value('a)=?,
+      ~rotateX: AnimatedRe.value('a)=?,
+      ~rotateY: AnimatedRe.value('a)=?,
+      ~rotateZ: AnimatedRe.value('a)=?,
+      ~scaleX: AnimatedRe.value('a)=?,
+      ~scaleY: AnimatedRe.value('a)=?,
+      ~translateX: AnimatedRe.value('a)=?,
+      ~translateY: AnimatedRe.value('a)=?,
+      ~skewX: AnimatedRe.value('a)=?,
+      ~skewY: AnimatedRe.value('a)=?,
       unit
     ) =>
     styleElement;


### PR DESCRIPTION
This PR updates Style module to reduce complexity when working with `Animated` values. Fixes #246 

It's a breaking change. There's no `Interpolated(value)` now to be used when defining a style. Use `Animated(value)` instead. 

