### PR TITLE
Fix links in docs

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -4,7 +4,7 @@
   "reason": {"react-jsx": 2},
   "refmt": 3,
   "bs-dependencies": ["reason-react"],
-  "namespace": true,
+  "namespace": false,
   "sources": [
     {
       "dir": "src",


### PR DESCRIPTION
Since https://github.com/ocaml/odoc/pull/204 got in `odoc`, I figured I'd have a look at what's breaking the links around here.

Turns out the autonamespacing is messing this up because it rewrites every module name under the hood. From `PermissionsAndroid` to `PermissionsAndroid-BsReactNative`.

I tried making the docs aware of this and reference modules by their namespaced name (such as `PermissionsAndroid-BsReactNative` instead of just `PermissionsAndroid`), but it's not actually possible since `PermissionsAndroid-BsReactNative` is not a valid OCaml module identifier and `odoc` is using standard OCaml parsing libraries to read the typed trees.

Manual namespacing is really not that big of a deal, and OCaml/Erlang/others have been doing it for 20+ years without much problem. Renaming a module to `RN_` like `RN_PermissionsAndroid` still lets you have a top-level `ReactNative` module that does the appropriate re-exports as you see fit.

Just my 2 cents on the issue 🙏 

cc/ @grabbou 