### PR TITLE
Adds nativeEvent parameter to onEndEditing in TextInput

### DIFF
--- a/src/components/textInput.rei
+++ b/src/components/textInput.rei
@@ -102,7 +102,16 @@ let make:
                           } =>
                           unit
                             =?,
-    ~onEndEditing: unit => unit=?,
+    ~onEndEditing: {
+                     .
+                     "nativeEvent": {
+                       .
+                       "text": string,
+                       "target": int,
+                     },
+                   } =>
+                   unit
+                     =?,
     ~onFocus: unit => unit=?,
     ~onScroll: {
                  .


### PR DESCRIPTION
TextInput.onEndEditing in react-native sends a native event containing the text and the id of the target.

This PR adds a binding for it.

Android source:
https://github.com/facebook/react-native/blob/master/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.java#L47-L51

iOS source:

iOS event: https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/React/Base/RCTEventDispatcher.m#L111-L118

Event is sent here without a key and with the current text
https://github.com/facebook/react-native/blob/master/Libraries/Text/TextInput/RCTBaseTextInputView.m#L251-L256
