### PR TITLE
Migrating FlatList docs from rebolt

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -4,6 +4,15 @@ dt#type-calculated {
   display: none;
 }
 
+#module-type-FlatListComponent, #module-CreateComponent, #module-CreateComponent ~ div > .include.spec details summary {
+  display: none;
+}
+
+#module-CreateComponent ~ div dl {
+  display: flex;
+  flex-direction: column-reverse;
+}
+
 .content > dl > dd {
   padding: 0;
   padding-top: 0.75em;

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -8,6 +8,10 @@ dt#type-calculated {
   display: none;
 }
 
+#module-type-FlatListComponent, #module-CreateComponent, #module-CreateComponent ~ div > .include.spec details {
+  overflow: hidden;
+}
+
 #module-CreateComponent ~ div dl {
   display: flex;
   flex-direction: column-reverse;

--- a/src/components/flatList.rei
+++ b/src/components/flatList.rei
@@ -1,5 +1,244 @@
+
+
+/************* */
 module type FlatListComponent = {
+  /**
+    {3 Example of use}
+    In order to render a FlatList {{:https://facebook.github.io/react-native/docs/flatlist}} in React Native you need to provide three props:
+    
+    - [data]
+    - [renderItem]
+    - [keyExtractor]
+
+   {4 default} 
+   {[
+      type contact = {
+        id: int,
+        name: string,
+        count: int,
+      };
+      type myData = array(contact);
+      let myData = [|
+        {id: 1, name: "Davin Roth", count: 645},
+        {id: 2, name: "Milton Walsh", count: 12},
+      |];
+
+      let myKeyExtractor = (item, _index) => string_of_int(item.id);
+
+      let renderMyItem =
+        FlatList.renderItem((contact: FlatList.renderBag(contact)) =>
+          <View> <Text> (ReasonReact.string(contact.item.name)) </Text> </View>
+        );
+
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <FlatList
+            data=myData
+            keyExtractor=myKeyExtractor
+            renderItem=renderMyItem
+          />,
+      };
+
+   ]}
+
+  {3 Props}
+  {4 data}
+  {[
+    data: array('item)
+  ]}
+  {4 renderItem}
+  {[
+    renderItem: renderItem('item)
+  ]}
+  {4 keyExtractor}
+  {[
+    keyExtractor: ('item, int) => string
+  ]}
+  {4 itemSeparatorComponent}
+  {[
+    itemSeparatorComponent: separatorComponent('item)=?
+  ]}
+  {{:#val-separatorComponent} separatorComponent reference}
+  {4 bounces}
+  {[
+    bounces: bool=?
+  ]}
+  {4 listFooterComponent}
+  {[
+    listFooterComponent: ReasonReact.reactElement=?
+  ]}
+  {4 listHeaderComponent}
+  {[
+    listHeaderComponent: ReasonReact.reactElement=?
+  ]}
+  {4 columnWrapperStyle}
+  {[
+    columnWrapperStyle: Style.t=?
+  ]}
+  {4 extraData}
+  {[
+    extraData: 'any=?
+  ]}
+  {4 getItemLayout}
+  {[
+    getItemLayout: (option(array('item)), int) => {
+      .
+      "length": int,
+      "offset": int,
+      "index": int,
+    }=?
+  ]}
+  {4 horizontal}
+  {[
+    horizontal: bool=?
+  ]}
+  {4 initialNumToRender}
+  {[
+    initialNumToRender: int=?
+  ]}
+  {4 initialScrollIndex}
+  {[
+    initialScrollIndex: int=?
+  ]}
+  {4 inverted}
+  {[
+    inverted: bool=?
+  ]}
+  {4 numColumns}
+  {[
+    numColumns: 'int=?
+  ]}
+  {4 onEndReached}
+  {[
+    onEndReached: {. "distanceFromEnd": float} => unit=?
+  ]}
+  {4 onEndReachedThreshold}
+  {[
+    onEndReachedThreshold: float=?
+  ]}
+  {4 onRefresh}
+  {[
+    onRefresh: unit => unit=?
+  ]}
+  {4 onViewableItemsChanged}
+  {[
+    onViewableItemsChanged: {
+      .
+      "viewableItems":
+        array(
+          {
+            .
+            "item": 'item,
+            "key": string,
+            "index": Js.undefined(int),
+            "isViewable": bool,
+            "section": Js.t({.}),
+          },
+        ),
+      "changed":
+        array(
+          {
+            .
+            "item": 'item,
+            "key": string,
+            "index": Js.undefined(int),
+            "isViewable": bool,
+            "section": Js.t({.}),
+          },
+        ),
+    }=?
+  ]}
+  {4 overScrollMode}
+  {[
+    overScrollMode: [
+      | `auto
+      | `always
+      | `never
+    ]=?
+  ]}
+  {4 pagingEnabled}
+  {[
+    pagingEnabled: bool=?
+  ]}
+  {4 refreshing}
+  {[
+    refreshing: bool=?
+  ]}
+  {4 removeClippedSubviews}
+  {[
+    removeClippedSubviews: bool=?
+  ]}
+  {4 scrollEnabled}
+  {[
+    scrollEnabled: bool=?
+  ]}
+  {4 showsHorizontalScrollIndicator}
+  {[
+    showsHorizontalScrollIndicator: bool=?
+  ]}
+  {4 showsVerticalScrollIndicator}
+  {[
+    showsVerticalScrollIndicator: bool=?
+  ]}
+  {4 windowSize}
+  {[
+    windowSize: int=?
+  ]}
+  {4 maxToRenderPerBatch}
+  {[
+    maxToRenderPerBatch: int=?
+  ]}
+  {4 viewabilityConfig}
+  {[
+    viewabilityConfig: Js.t({.})=?
+  ]}
+  {4 onScroll}
+  {[
+    onScroll: RNEvent.NativeScrollEvent.t => unit=?
+  ]}
+  reference:
+  {4 RNEvent.rei}
+  {[
+    module NativeScrollEvent: {
+      type t;
+      type point = {
+        x: float,
+        y: float
+      };
+      type size = {
+        width: float,
+        height: float
+      };
+      type contentInset = {
+        bottom: float,
+        top: float,
+        left: float,
+        right: float
+      };
+      let contentOffset: t => point;
+      let contentSize: t => size;
+      let contentInset: t => contentInset;
+      let layoutMeasurement: t => size;
+    };
+  ]}
+  {4 style}
+  {[
+    style: Style.t=?
+  ]}
+  */
+  /**
+    {3 methods }
+    {4 scrollToEnd}
+  */
+ 
   let scrollToEnd: (ReasonReact.reactRef, ~animated: bool) => unit;
+
+  /**
+  {4 scrollToIndex}
+  */
 
   let scrollToIndex:
     (
@@ -12,6 +251,10 @@ module type FlatListComponent = {
     ) =>
     unit;
 
+  /**
+  {4 scrollToItem}
+  */
+
   let scrollToItem:
     (
       ReasonReact.reactRef,
@@ -22,9 +265,16 @@ module type FlatListComponent = {
     ) =>
     unit;
 
+  /**
+  {4 scrollToOffset}
+  */  
+
   let scrollToOffset:
     (ReasonReact.reactRef, ~offset: float=?, ~animated: bool=?, unit) => unit;
 
+/**
+{2 API reference}
+*/
   [@bs.send] external recordInteraction: ReasonReact.reactRef => unit = "";
 
   type renderBag('item) = {
@@ -37,6 +287,7 @@ module type FlatListComponent = {
   let renderItem:
     (renderBag('item) => ReasonReact.reactElement) => renderItem('item);
 
+  
   type separatorComponent('item);
 
   type separatorProps('item) = {


### PR DESCRIPTION
Migrated FlatList from rebolt. 

Due to the fact odoc puts comments below definitions there are custom css hacks which I don't really like 😕 So suggest other ways of putting docs section above module.

Also CreateComponent and FlatListComponent modules are hidden from the doc for that same reason.

![screencapture-127-0-0-1-8080-bsreactnative-flatlist-bsreactnative-2018-10-09-23_50_01](https://user-images.githubusercontent.com/3762909/46697858-485deb80-cc1e-11e8-8588-e09f9bb476a0.png)

#267