### PR TITLE
Migrating Image and Modal docs from rebolt to bs-react-native

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -4,15 +4,24 @@ dt#type-calculated {
   display: none;
 }
 
-#module-type-FlatListComponent, #module-CreateComponent, #module-CreateComponent ~ div > .include.spec details summary {
+#module-type-FlatListComponent,
+#module-type-ImageComponent,
+#module-CreateComponent, 
+#module-CreateComponent ~ article summary,
+#module-CreateComponent ~ div summary
+{
   display: none;
 }
 
-#module-type-FlatListComponent, #module-CreateComponent, #module-CreateComponent ~ div > .include.spec details {
+#module-type-FlatListComponent, 
+#module-CreateComponent, 
+#module-CreateComponent ~ div > .include.spec details,
+#module-CreateComponent ~ article > .include.spec details {
   overflow: hidden;
 }
 
-#module-CreateComponent ~ div dl {
+#module-CreateComponent ~ div dl,
+#module-CreateComponent ~ article dl {
   display: flex;
   flex-direction: column-reverse;
 }

--- a/src/components/image.rei
+++ b/src/components/image.rei
@@ -1,4 +1,220 @@
 module type ImageComponent = {
+  /**
+    {3 Example of use}
+    [Image] component {{:https://facebook.github.io/react-native/docs/image}} requires the [source] prop, here is the example usage. Note that you also need to specify the width and height, this can be done via [imageURISource] named arguments, or via [style] prop that is passed to [Image] component
+
+    {2 source from URI}
+    {[ 
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Image
+            source=(
+              `URI(
+                Image.(
+                  imageURISource(
+                    ~uri="https://bit.ly/2ya4e2o",
+                    ~width=Pt(320.),
+                    ~height=Pt(480.),
+                    (),
+                  )
+                ),
+              )
+            )
+          />,
+      };
+    ]}
+    {4 source from a file path}
+    One thing to remember here is that the path is relative to the compiled code.
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Image
+            style=Style.(style([width(Pt(320.)), height(Pt(480.))]))
+            source=(`Required(Packager.require("./assets/panamera.png")))
+          />,
+      };
+    ]}
+    {3 Props}
+    {4 onError}
+    {[
+      onError: Event.error => unit=?
+    ]}
+    {{:#module-Event} [Event]}
+    {4 onLayout}
+    {[
+      onLayout: RNEvent.NativeLayoutEvent.t => unit=?
+    ]}
+    reference:
+    {4 RNEvent.rei}
+    {[
+      module NativeLayoutEvent: {
+        type t;
+        type layout = {
+          x: float,
+          y: float,
+          width: float,
+          height: float
+        };
+        let layout: t => layout;
+      };
+    ]}
+    {4 onLoad}
+    {[
+      onLoad: unit => unit=?
+    ]}
+    {4 onLoadEnd}
+    {[
+      onLoadEnd: unit => unit=?
+    ]}
+    {4 onLoadStart}
+    {[
+      onLoadStart: unit => unit=?
+    ]}
+    {4 resizeMode}
+    {[
+      resizeMode: [<
+        | `center
+        | `contain
+        | `cover
+        | `repeat
+        | `stretch
+      ]=?
+    ]}
+    {4 source}
+    {[
+      source: imageSource
+    ]}
+    {{:#type-imageSource} reference:}
+    {[
+      let _imageURISource:
+        (
+          ~uri: string,
+          ~bundle: string=?,
+          ~method: string=?,
+          ~headers: Js.t('a)=?,
+          ~body: string=?,
+          ~cache: [ | `default | `reload | `forceCache | `onlyIfCached]=?,
+          ~scale: float=?,
+          ~width: option(float)=?,
+          ~height: option(float)=?,
+          unit
+        ) =>
+        _imageURISource;
+    ]}
+    {[
+      type pt_only =
+        | Pt(float);
+
+      type imageURISource;
+
+      let imageURISource:
+        (
+          ~uri: string,
+          ~bundle: string=?,
+          ~method: string=?,
+          ~headers: Js.t('a)=?,
+          ~body: string=?,
+          ~cache: [ | `default | `reload | `forceCache | `onlyIfCached]=?,
+          ~scale: float=?,
+          ~width: Style.pt_only=?,
+          ~height: Style.pt_only=?,
+          unit
+        ) =>
+        _imageURISource;
+    ]}
+    {4 style}
+    {[
+      style: Style.t=?
+    ]}
+    {4 testID}
+    {[
+      testID: string=?
+    ]}
+    {4 resizeMethod}
+    {[
+      resizeMethod: [<
+        | `auto
+        | `resize
+        | `scale
+      ]=?
+    ]}
+    {4 accessibilityLabel}
+    {[
+      accessibilityLabel: string=?
+    ]}
+    {4 blurRadius}
+    {[
+      blurRadius: float=?
+    ]}
+    {4 capInsets}
+    {[
+      capInsets: Types.insets=?
+    ]}
+    reference:
+    {[
+      type insets = {
+        .
+        "left": int,
+        "right": int,
+        "top": int,
+        "bottom": int,
+      };
+    ]}
+    {4 defaultSource}
+    {[
+      defaultSource: defaultSource=?
+    ]}
+    {{:#defaultsource} reference:}
+    {[
+      type defaultSource = [
+        | `URI(_defaultURISource)
+        | `Required(Packager.required)
+      ];
+    ]}
+    {[
+      let _defaultURISource:
+        (
+          ~uri: string,
+          ~scale: float=?,
+          ~width: option(float)=?,
+          ~height: option(float)=?,
+          unit
+        ) =>
+        _defaultURISource;
+    ]}
+    {[
+      let defaultURISource:
+        (
+          ~uri: string,
+          ~scale: float=?,
+          ~width: Style.pt_only=?,
+          ~height: Style.pt_only=?,
+          unit
+        ) =>
+        _defaultURISource;
+    ]}
+    {[
+      type pt_only =
+        | Pt(float);
+    ]}
+    {4 onPartialLoad}
+    {[
+      onPartialLoad: unit => unit=?
+    ]}
+    {4 onProgress}
+    {[
+      onProgress: Event.progress => unit=?
+    ]}
+    {{:#module-Event} [Event]}
+
+  {2 API reference}
+  */
   type _imageURISource;
   let _imageURISource:
     (
@@ -62,6 +278,9 @@ module type ImageComponent = {
     | `URI(_defaultURISource)
     | `Required(Packager.required)
   ];
+
+
+
   module Event: {
     type error;
     type progress = {
@@ -69,6 +288,7 @@ module type ImageComponent = {
       total: float,
     };
   };
+
   let make:
     (
       ~onError: Event.error => unit=?,

--- a/src/components/modal.rei
+++ b/src/components/modal.rei
@@ -1,3 +1,144 @@
+/**
+    {3 Example of use}
+    [Modal] component {{:https://facebook.github.io/react-native/docs/modal}} simply displays content over an enclosing view.
+
+    {4 default}
+    Wrap some content in [<Modal></Modal>] and you are good to go
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Modal>
+            <View
+              style=Style.(
+                      style([
+                        flex(1.),
+                        justifyContent(Center),
+                        alignItems(Center),
+                        backgroundColor(String("tomato")),
+                      ])
+                    )>
+              <Text> (ReasonReact.string("hey ho")) </Text>
+            </View>
+          </Modal>,
+      };
+    ]}
+    {3 Props}
+    {4 animationType}
+    {[
+      animationType: [
+        | `fade
+        | `none
+        | `slide
+      ]=?
+    ]}
+    And this is how you apply one of those types:
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Modal animationType=`slide>
+            <View
+              style=Style.(
+                      style([
+                        flex(1.),
+                        justifyContent(Center),
+                        alignItems(Center),
+                        backgroundColor(String("tomato")),
+                      ])
+                    )>
+              <Text> (ReasonReact.string("hey ho")) </Text>
+            </View>
+          </Modal>,
+      };
+    ]}
+
+    {4 onShow}
+    {[
+      onShow: unit => unit=?
+    ]}
+    Example:
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Modal onShow=(() => Js.log("Just displayed the modal..."))>
+            <View
+              style=Style.(
+                      style([
+                        flex(1.),
+                        justifyContent(Center),
+                        alignItems(Center),
+                        backgroundColor(String("tomato")),
+                      ])
+                    )>
+              <Text> (ReasonReact.string("hey ho")) </Text>
+            </View>
+          </Modal>,
+      };
+    ]}
+    {4 transparent}
+    {[
+      transparent: bool=?
+    ]}
+    {4 visible}
+    {[
+      visible: bool=?
+    ]}
+    {4 hardwareAccelerated}
+    {[
+      hardwareAccelerated: bool=?
+    ]}
+    {4 onRequestClose}
+    {[
+      onRequestClose: unit => unit=?
+    ]}
+    {4 onOrientationChange}
+    {[
+      onOrientationChange: unit => unit=?
+    ]}
+    {4 supportedOrientations}
+    {[
+      supportedOrientations: array(
+        [
+          | `landscape
+          | `landscapeLeft
+          | `landscapeRight
+          | `portrait
+          | `portraitUpsideDown
+        ],
+      )=?
+    ]}
+    Example:
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <Modal supportedOrientations=[|`landscape, `portrait|]>
+            <View
+              style=Style.(
+                      style([
+                        flex(1.),
+                        justifyContent(Center),
+                        alignItems(Center),
+                        backgroundColor(String("tomato")),
+                      ])
+                    )>
+              <Text> (ReasonReact.string("hey ho")) </Text>
+            </View>
+          </Modal>,
+      };
+    ]}
+
+*/
 let make:
   (
     ~animationType: [ | `fade | `none | `slide]=?,


### PR DESCRIPTION
- Migrated Image and Modal to bs-react-native with a bit changes for Modal as part of working on issue: #267 
- added additional custom css for ImageComponent.
- included both `article` and `div` cause on dev docs are built with divs but in deployed docs with `article`
