### PR TITLE
pickers and progress bars docs migration and enhancements

### DIFF
--- a/lib/js/src/components/picker.js
+++ b/lib/js/src/components/picker.js
@@ -44,6 +44,6 @@ function make$1(onValueChange, selectedValue, enabled, mode, prompt, itemStyle, 
     });
 }
 
-exports.Item = Item;
 exports.make = make$1;
+exports.Item = Item;
 /* ReasonReact Not a pure module */

--- a/lib/js/src/components/pickerIOS.js
+++ b/lib/js/src/components/pickerIOS.js
@@ -31,6 +31,6 @@ function make$1(itemStyle, onValueChange, selectedValue, accessibilityLabel, acc
     });
 }
 
-exports.Item = Item;
 exports.make = make$1;
+exports.Item = Item;
 /* ReasonReact Not a pure module */

--- a/src/components/imageBackground.rei
+++ b/src/components/imageBackground.rei
@@ -1,3 +1,8 @@
+/**
+  [ImageBackground] component has the same props as {{:\BsReactNative/Image-BsReactNative} [Image] component}
+  You can read more on ImageBackground component usage in official docs: {{:https://facebook.github.io/react-native/docs/images}}
+*/
+
 module Event: {
   type error;
   type progress = {

--- a/src/components/picker.rei
+++ b/src/components/picker.rei
@@ -1,18 +1,255 @@
-module Item: {
-  let make:
-    (
-      ~color: string=?,
-      ~label: string,
-      ~value: 'value=?,
-      ~testID: string=?,
-      array(ReasonReact.reactElement)
-    ) =>
-    ReasonReact.component(
-      ReasonReact.stateless,
-      ReasonReact.noRetainedProps,
-      unit,
-    );
-};
+
+/**
+    {3 Example of use}
+    In order to render a [Picker] component {{:https://facebook.github.io/react-native/docs/picker}} you will need to pass one or many [Picker.Item]
+    components as children.
+    
+    And [Picker.Item] has a required [label] prop
+
+    {4 default}
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <View>
+            <Picker>
+              <Picker.Item label="ReasonML" value="reason" />
+              <Picker.Item label="Ocaml" value="ocaml" />
+              <Picker.Item label="JavaScript" value="js" />
+            </Picker>
+          </View>,
+      };
+    ]}
+    {4 selectedValue and onValueChange}
+    {[
+      let component = ReasonReact.statelessComponent("MyComponent");
+
+      let make = _children => {
+        ...component,
+        render: _self =>
+          <View>
+            <Picker selectedValue="ocaml" onValueChange=(value => Js.log(value))>
+              <Picker.Item label="ReasonML" value="reason" />
+              <Picker.Item label="Ocaml" value="ocaml" />
+              <Picker.Item label="JavaScript" value="js" />
+            </Picker>
+          </View>,
+      };  
+    ]}
+    {3 Props}
+    {4 onValueChange}
+    {[
+      onValueChange: 'value => unit=?
+    ]}
+    {4 selectedValue}
+    {[
+      selectedValue: 'value=?
+    ]}
+    {4 enabled}
+    {[
+      enabled: bool=?
+    ]}
+    {4 mode}
+    On {b Android only}, specifies how to display the selection items when the user taps on the picker:
+
+    - [`dialog] - shows a modal dialog. This is the default.
+    - [`dropdown] - shows a dropdown anchored to the picker view
+    {[
+      mode: [
+        | `dialog
+        | `dropdown
+      ]=?
+    ]}
+    {4 prompt}
+    {[
+      prompt: string=?
+    ]}
+    {4 itemStyle}
+    {[
+      itemStyle: Style.t=?
+    ]}
+    {4 accessibilityLabel}
+    {[
+      accessibilityLabel: ReasonReact.reactElement=?
+    ]}
+    {4 accessible}
+    {[
+      accessible: bool=?
+    ]}
+    {4 hitSlop}
+    {[
+      hitSlop: Types.insets=?
+    ]}
+    reference: 
+    {4 Types.rei}
+    {[
+      type insets = {
+        .
+        "left": int,
+        "right": int,
+        "top": int,
+        "bottom": int,
+      };
+    ]}
+    {4 onAccessibilityTap}
+    {[
+      onAccessibilityTap: unit => unit=?
+    ]}
+    {4 onLayout}
+    {[
+      onLayout: RNEvent.NativeLayoutEvent.t => unit=?
+    ]}
+    reference:
+    {4 RNEvent.rei}
+    {[
+      module NativeLayoutEvent: {
+        type t;
+        type layout = {
+          x: float,
+          y: float,
+          width: float,
+          height: float
+        };
+        let layout: t => layout;
+      };
+    ]}
+    {4 onMagicTap}
+    {[
+      onMagicTap: unit => unit=?
+    ]}
+    {4 responderHandlers}
+    {[
+      responderHandlers: Types.touchResponderHandlers=?
+    ]}
+    reference:
+    {4 Types.rei}
+    {[
+      type touchResponderHandlers = {
+        onMoveShouldSetResponder: option(RNEvent.NativeEvent.t => bool),
+        onMoveShouldSetResponderCapture: option(RNEvent.NativeEvent.t => bool),
+        onResponderGrant: option(RNEvent.NativeEvent.t => unit),
+        onResponderMove: option(RNEvent.NativeEvent.t => unit),
+        onResponderReject: option(RNEvent.NativeEvent.t => unit),
+        onResponderRelease: option(RNEvent.NativeEvent.t => unit),
+        onResponderTerminate: option(RNEvent.NativeEvent.t => unit),
+        onResponderTerminationRequest: option(RNEvent.NativeEvent.t => unit),
+        onStartShouldSetResponder: option(RNEvent.NativeEvent.t => bool),
+        onStartShouldSetResponderCapture: option(RNEvent.NativeEvent.t => bool)
+      };
+    ]}
+    {4 RNEvent.rei}
+    {[
+      module NativeEvent: {
+        type t;
+        let changedTouches: t => array(Js.t({..}));
+        let identifier: t => int;
+        let locationX: t => float;
+        let locationY: t => float;
+        let pageX: t => float;
+        let pageY: t => float;
+        let target: t => Js.t({..});
+        let touches: t => array(Js.t({..}));
+        let timestamp: t => int;
+        let data: t => string;
+      };
+    ]}
+    {4 pointerEvents}
+    {[
+      pointerEvents: [
+        | `auto
+        | `none
+        | `boxNone
+        | `boxOnly
+      ]=?
+    ]}
+    {4 removeClippedSubviews}
+    {[
+      removeClippedSubviews: bool=?
+    ]}
+    {4 style}
+    {[
+      style: Style.t=?
+    ]}
+    {4 testID}
+    {[
+      testID: string=?
+    ]}
+    {4 accessibilityComponentType} 
+    {[
+      accessibilityComponentType: [
+        | `none
+        | `button
+        | `radiobutton_checked
+        | `radiobutton_unchecked
+      ]=?
+    ]}
+    {4 accessibilityLiveRegion}
+    {[
+      accessibilityLiveRegion: [
+        | `none
+        | `polite
+        | `assertive
+      ]=?
+    ]}
+    {4 collapsable}
+    {[
+      collapsable: bool=?
+    ]}
+    {4 importantForAccessibility}
+    {[
+      importantForAccessibility: [
+        | `auto
+        | `yes
+        | `no
+        | `noHideDescendants
+      ]=?
+    ]}
+    {4 needsOffscreenAlphaCompositing}
+    {[
+      needsOffscreenAlphaCompositing: bool=?
+    ]}
+    {4 renderToHardwareTextureAndroid}
+    {[
+      renderToHardwareTextureAndroid: bool=?
+    ]}
+    {4 accessibilityTraits}
+    {[
+      accessibilityTraits: list(
+        [
+          | `none
+          | `button
+          | `link
+          | `header
+          | `search
+          | `image
+          | `selected
+          | `plays
+          | `key
+          | `text
+          | `summary
+          | `disabled
+          | `frequentUpdates
+          | `startsMedia
+          | `adjustable
+          | `allowsDirectInteraction
+          | `pageTurn
+        ]
+      )=?
+    ]}
+    {4 accessibilityViewIsModal}
+    {[
+      accessibilityViewIsModal: bool=?
+    ]}
+    {4 shouldRasterizeIOS}
+    {[
+      shouldRasterizeIOS: bool=?
+    ]}
+*/
+
+
+
 
 let make:
   (
@@ -76,3 +313,37 @@ let make:
     ReasonReact.noRetainedProps,
     unit,
   );
+
+/**
+  [Picker.Item] component is used {b only} inside [<Picker></Picker>] component
+  
+  {3 Props}
+  {4 label}
+  {[
+    label: string
+  ]}
+  {4 color}
+  {[
+    color: string=?
+  ]}
+  {4 value}
+  {[
+    value: 'value=?
+  ]}
+*/
+
+module Item: {
+  let make:
+    (
+      ~color: string=?,
+      ~label: string,
+      ~value: 'value=?,
+      ~testID: string=?,
+      array(ReasonReact.reactElement)
+    ) =>
+    ReasonReact.component(
+      ReasonReact.stateless,
+      ReasonReact.noRetainedProps,
+      unit,
+    );
+};

--- a/src/components/pickerIOS.rei
+++ b/src/components/pickerIOS.rei
@@ -1,18 +1,53 @@
-module Item: {
-  let make:
-    (
-      ~label: string,
-      ~value: 'value=?,
-      ~color: string=?,
-      array(ReasonReact.reactElement)
-    ) =>
-    ReasonReact.component(
-      ReasonReact.stateless,
-      ReasonReact.noRetainedProps,
-      unit,
-    );
-};
+/**
+  {3 Example of use}
+  In order to render a [PickerIOS] {{:https://facebook.github.io/react-native/docs/pickerios}} component you will need to pass one or many [PickerIOS.Item] component(s) as children.
 
+  And [PickerIOS.Item] has a required label prop
+  {[
+    let component = ReasonReact.statelessComponent("MyComponent");
+
+    let make = _children => {
+      ...component,
+      render: _self =>
+        <View>
+          <PickerIOS>
+            <PickerIOS.Item label="ReasonML" value="reason" />
+            <PickerIOS.Item label="Ocaml" value="ocaml" />
+            <PickerIOS.Item label="JavaScript" value="js" />
+          </PickerIOS>
+        </View>,
+    };
+  ]}
+  {4 selectedValue and onValueChange}
+  {[
+    let component = ReasonReact.statelessComponent("MyComponent");
+
+    let make = _children => {
+      ...component,
+      render: _self =>
+        <View>
+          <PickerIOS selectedValue="ocaml" onValueChange=(value => Js.log(value))>
+            <PickerIOS.Item label="ReasonML" value="reason" />
+            <PickerIOS.Item label="Ocaml" value="ocaml" />
+            <PickerIOS.Item label="JavaScript" value="js" />
+          </PickerIOS>
+        </View>,
+    };  
+  ]}
+  {3 Props}
+  {4 itemStyle}
+  {[
+    itemStyle: Style.t=?
+  ]}
+  {4 onValueChange}
+  {[
+    onValueChange: 'value => unit=?
+  ]}
+  {4 selectedValue}
+  {[
+    selectedValue: 'value=?
+  ]}
+*/
 let make:
   (
     ~itemStyle: Style.t=?,
@@ -72,3 +107,37 @@ let make:
     ReasonReact.noRetainedProps,
     ReasonReact.actionless,
   );
+
+/**
+  [PickerIOS.Item] component is used {b only} inside [<PickerIOS></PickerIOS>] component
+  
+  {3 Props}
+  {4 label}
+  {[
+    label: string
+  ]}
+  {4 color}
+  {[
+    color: string=?
+  ]}
+  {4 value}
+  {[
+    value: 'value=?
+  ]}
+*/
+
+
+module Item: {
+  let make:
+    (
+      ~label: string,
+      ~value: 'value=?,
+      ~color: string=?,
+      array(ReasonReact.reactElement)
+    ) =>
+    ReasonReact.component(
+      ReasonReact.stateless,
+      ReasonReact.noRetainedProps,
+      unit,
+    );
+};

--- a/src/components/progressBarAndroid.rei
+++ b/src/components/progressBarAndroid.rei
@@ -1,3 +1,72 @@
+/**
+ {b Android-only} component {{:https://facebook.github.io/react-native/docs/progressbarandroid}} used to indicate that the app is loading or there is some activity in the app.
+ 
+ {3 Example of use}
+ {4 Horizontal}
+ {[
+    let component = ReasonReact.statelessComponent("ExampleHorizontal");
+
+    let make = _children => {
+      ...component,
+      render: _children =>
+        <View>
+          <ProgressBarAndroid styleAttr=`Horizontal />
+          <ProgressBarAndroid styleAttr=`Horizontal color="#2196F3" />
+          <ProgressBarAndroid styleAttr=`Horizontal progress=0.5 />
+        </View>,
+    };
+ ]}
+ {4 Inverse}
+ {[
+  let component = ReasonReact.statelessComponent("ExampleInverse");
+
+  let make = _children => {
+    ...component,
+    render: _children =>
+      <View>
+        <ProgressBarAndroid styleAttr=`Inverse />
+        <ProgressBarAndroid styleAttr=`Inverse color="#2196F3" />
+      </View>,
+  };
+ ]}
+ {3 Props}
+ {{:\BsReactNative/View-BsReactNative} [View] props}
+ {4 color}
+ {[
+   ~color: string=?,
+ ]}
+ {4 animating}
+ {[
+   ~animating: bool=?,
+ ]}
+ {4 indeterminate}
+ If the progress bar will show indeterminate progress. Note that this can only be false if [StyleAttr=`Horizontal]
+ {[
+   ~indeterminate: bool=?,
+ ]}
+ {4 progress}
+ Value between 0 and 1
+ {[
+  ~progress: float=?,
+ ]}
+ {4 styleAttr}
+ {[
+   ~styleAttr: [
+                | `Horizontal
+                | `Normal (default)
+                | `Small
+                | `Large
+                | `Inverse
+                | `SmallInverse
+                | `LargeInverse
+            ]
+                =?,
+ ]}
+ {4 testID}
+ {[
+   ~testID: string=?,
+ ]}
+*/
 let make:
   (
     ~animating: bool=?,

--- a/src/components/progressViewIOS.rei
+++ b/src/components/progressViewIOS.rei
@@ -1,3 +1,44 @@
+/**
+ Use [ProgressViewIOS] {{:https://facebook.github.io/react-native/docs/progressviewios}} to render a [UIProgressView] on iOS.
+
+ {3 Example of use}
+  {[
+    let component = ReasonReact.statelessComponent("MyComponent");
+
+    let make = _children => {
+      ...component,
+      render: _self => <ProgressViewIOS progress=0.4 progressTintColor="tomato" />,
+    };
+  ]}
+ 
+ {3 Props}
+ {{:\BsReactNative/View-BsReactNative} [View] props}
+ {4 progress}
+ {[
+   ~progress: float
+ ]}
+ {4 progressImage}
+ {[
+   ~progressImage: Image.imageSource=?
+ ]}
+ {4 progressTintColor}
+ {[
+   ~progressTintColor: string=?
+ ]}
+ {4 progressViewStyle}
+ {[
+   ~progressViewStyle: Style.t=?
+ ]}
+ {4 trackImage}
+ {[
+   trackImage: Image.imageSource=?
+ ]}
+ {4 trackTintColor}
+ {[
+   ~trackTintColor: string=?
+ ]}
+*/
+
 let make:
   (
     ~progress: float,


### PR DESCRIPTION
- Added ImageBackground docs reference as well as reference to Image docs
![imagebackground](https://user-images.githubusercontent.com/3762909/47082024-ff58f900-d214-11e8-9aae-2ae5ccef496f.png)

- Migrated Picker component docs from rebolt with some additions
![picker](https://user-images.githubusercontent.com/3762909/47081972-dc2e4980-d214-11e8-9967-2aba16ca1a7f.png)

- Migrated PickerIOS component docs from rebolt with some additions
![pickerios](https://user-images.githubusercontent.com/3762909/47081975-dfc1d080-d214-11e8-8df5-23f8d061dfb0.png)

- Migrated ProgressBarAndroid docs from rebolt
![progressbarandroid](https://user-images.githubusercontent.com/3762909/47081985-e3555780-d214-11e8-9f18-fd33cc963566.png)

- Migrated ProgressViewIOS docs from rebolt
![progressviewios](https://user-images.githubusercontent.com/3762909/47081989-e5b7b180-d214-11e8-85c6-19a6206eb955.png)

#267 