### PR TITLE
Add trackColor property to Switch (onTintColor is deprecated) 

### DIFF
--- a/src/components/switch.re
+++ b/src/components/switch.re
@@ -3,6 +3,7 @@
 let make =
     (
       ~disabled: option(bool)=?,
+      ~trackColor: option(string)=?,
       ~onTintColor: option(string)=?,
       ~onValueChange: option(bool => unit)=?,
       ~thumbTintColor: option(string)=?,
@@ -37,6 +38,7 @@ let make =
           "value": value,
           "disabled": disabled,
           "onValueChange": onValueChange,
+          "trackColor": trackColor,
           "onTintColor": onTintColor,
           "thumbTintColor": thumbTintColor,
           "tintColor": tintColor,

--- a/src/components/switch.rei
+++ b/src/components/switch.rei
@@ -1,6 +1,7 @@
 let make:
   (
     ~disabled: bool=?,
+    ~trackColor: string=?,
     ~onTintColor: string=?,
     ~onValueChange: bool => unit=?,
     ~thumbTintColor: string=?,


### PR DESCRIPTION
`onTintColor` is deprecated in RN 0.57, I have added the replacement property to get rid of warnings.

For use with earlier versions of RN, `onTintColor` remains available.