### PR TITLE
Avoid test "exit 0" in package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start-docs": "live-server docs",
     "start": "bsb -make-world -w",
     "clean-build": "bsb -clean-world -make-world",
-    "test": "exit 0"
+    "test": "yarn clean-build && yarn build-docs"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
It's handy to have this shortcut to quickly check that everything is ok when you make a change in the repo. Don't you think?