### PR TITLE
Add testID prop to touchable components

### DIFF
--- a/lib/js/src/components/touchableHighlight.js
+++ b/lib/js/src/components/touchableHighlight.js
@@ -7,7 +7,7 @@ var ReasonReact = require("reason-react/lib/js/src/ReasonReact.js");
 var ReactNative = require("react-native");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
-function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onPress, onPressIn, onPressOut, pressRetentionOffset, activeOpacity, onHideUnderlay, onShowUnderlay, style, underlayColor, hasTVPreferredFocus, tvParallaxProperties) {
+function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onPress, onPressIn, onPressOut, pressRetentionOffset, activeOpacity, onHideUnderlay, onShowUnderlay, style, underlayColor, hasTVPreferredFocus, tvParallaxProperties, testID) {
   var partial_arg = {
     accessible: accessible,
     accessibilityLabel: accessibilityLabel,
@@ -96,7 +96,8 @@ function make(accessible, accessibilityLabel, accessibilityComponentType, access
     style: style,
     underlayColor: underlayColor,
     hasTVPreferredFocus: hasTVPreferredFocus,
-    tvParallaxProperties: tvParallaxProperties
+    tvParallaxProperties: tvParallaxProperties,
+    testID: testID
   };
   var partial_arg$1 = ReactNative.TouchableHighlight;
   return (function (param) {

--- a/lib/js/src/components/touchableNativeFeedback.js
+++ b/lib/js/src/components/touchableNativeFeedback.js
@@ -7,7 +7,7 @@ var ReasonReact = require("reason-react/lib/js/src/ReasonReact.js");
 var ReactNative = require("react-native");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
-function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onLongPress, onPress, onPressIn, onPressOut, pressRetentionOffset, style, background, useForeground) {
+function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onLongPress, onPress, onPressIn, onPressOut, pressRetentionOffset, style, background, useForeground, testID) {
   var partial_arg = {
     accessible: accessible,
     accessibilityLabel: accessibilityLabel,
@@ -93,7 +93,8 @@ function make(accessible, accessibilityLabel, accessibilityComponentType, access
               }
             };
             return $$Array.of_list(List.map(to_string, traits));
-          }), accessibilityTraits)
+          }), accessibilityTraits),
+    testID: testID
   };
   var partial_arg$1 = ReactNative.TouchableNativeFeedback;
   return (function (param) {

--- a/lib/js/src/components/touchableOpacity.js
+++ b/lib/js/src/components/touchableOpacity.js
@@ -7,7 +7,7 @@ var ReasonReact = require("reason-react/lib/js/src/ReasonReact.js");
 var ReactNative = require("react-native");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
-function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, style, onLayout, onPress, onLongPress, onPressIn, onPressOut, pressRetentionOffset, activeOpacity, focusedOpacity, tvParallaxProperties) {
+function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, style, onLayout, onPress, onLongPress, onPressIn, onPressOut, pressRetentionOffset, activeOpacity, focusedOpacity, testID, tvParallaxProperties) {
   var partial_arg = {
     accessible: accessible,
     accessibilityLabel: accessibilityLabel,
@@ -94,6 +94,7 @@ function make(accessible, accessibilityLabel, accessibilityComponentType, access
           }), accessibilityTraits),
     focusedOpacity: focusedOpacity,
     activeOpacity: activeOpacity,
+    testID: testID,
     tvParallaxProperties: tvParallaxProperties
   };
   var partial_arg$1 = ReactNative.TouchableOpacity;

--- a/lib/js/src/components/touchableWithoutFeedback.js
+++ b/lib/js/src/components/touchableWithoutFeedback.js
@@ -7,7 +7,7 @@ var ReasonReact = require("reason-react/lib/js/src/ReasonReact.js");
 var ReactNative = require("react-native");
 var UtilsRN$BsReactNative = require("../private/utilsRN.js");
 
-function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onLongPress, onPress, onPressIn, onPressOut, pressRetentionOffset, style) {
+function make(accessible, accessibilityLabel, accessibilityComponentType, accessibilityTraits, delayLongPress, delayPressIn, delayPressOut, disabled, hitSlop, onLayout, onLongPress, onPress, onPressIn, onPressOut, pressRetentionOffset, style, testID) {
   var partial_arg = {
     accessible: accessible,
     accessibilityLabel: accessibilityLabel,
@@ -91,7 +91,8 @@ function make(accessible, accessibilityLabel, accessibilityComponentType, access
               }
             };
             return $$Array.of_list(List.map(to_string, traits));
-          }), accessibilityTraits)
+          }), accessibilityTraits),
+    testID: testID
   };
   var partial_arg$1 = ReactNative.TouchableWithoutFeedback;
   return (function (param) {

--- a/src/components/touchableHighlight.re
+++ b/src/components/touchableHighlight.re
@@ -24,6 +24,7 @@ let make =
       ~underlayColor=?,
       ~hasTVPreferredFocus=?,
       ~tvParallaxProperties=?,
+      ~testID=?,
     ) =>
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
@@ -84,5 +85,6 @@ let make =
       "underlayColor": underlayColor,
       "hasTVPreferredFocus": hasTVPreferredFocus,
       "tvParallaxProperties": tvParallaxProperties,
+      "testID": testID,
     },
   );

--- a/src/components/touchableHighlight.rei
+++ b/src/components/touchableHighlight.rei
@@ -12,14 +12,14 @@ You can read more on [TouchableHighlight] component usage in official docs: {{:h
   ]}
   {4 onHideUnderlay}
   {[
-    ~onHideUnderlay: unit => unit=?    
+    ~onHideUnderlay: unit => unit=?
   ]}
   {4 onShowUnderlay}
   {[
     ~onShowUnderlay: unit => unit=?
   ]}
   {4 style}
-  {[ 
+  {[
     ~style: Style.t=?
   ]}
   {4 underlayColor}
@@ -34,9 +34,11 @@ You can read more on [TouchableHighlight] component usage in official docs: {{:h
   {[
     ~tvParallaxProperties: Js.t({.})=?
   ]}
+  {4 testID}
+  {[
+    ~testID: string=?
+  ]}
  */
-
-
 
 let make:
   (
@@ -88,6 +90,7 @@ let make:
     ~underlayColor: string=?,
     ~hasTVPreferredFocus: bool=?,
     ~tvParallaxProperties: Js.t({.})=?,
+    ~testID: string=?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(

--- a/src/components/touchableNativeFeedback.re
+++ b/src/components/touchableNativeFeedback.re
@@ -36,6 +36,7 @@ let make =
       ~style=?,
       ~background=?,
       ~useForeground=?,
+      ~testID=?,
     ) =>
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
@@ -93,5 +94,6 @@ let make =
           },
           accessibilityTraits,
         ),
+      "testID": testID,
     },
   );

--- a/src/components/touchableNativeFeedback.rei
+++ b/src/components/touchableNativeFeedback.rei
@@ -1,5 +1,3 @@
-
-
 type t;
 
 /**
@@ -92,6 +90,7 @@ let make:
     ~style: Style.t=?,
     ~background: t=?,
     ~useForeground: bool=?,
+    ~testID: string=?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(
@@ -112,7 +111,7 @@ let selectableBackground: unit => t;
  */
 let selectableBackgroundBorderless: unit => t;
 
-/** 
+/**
 {4 ripple}
 Creates an object that represents ripple drawable with specified color (as a string). If property borderless evaluates to true the ripple will render outside of the view bounds (see native actionbar buttons as an example of that behavior). This background type is available on Android API level 21+.
  */

--- a/src/components/touchableOpacity.re
+++ b/src/components/touchableOpacity.re
@@ -25,6 +25,7 @@ let make =
       ~pressRetentionOffset=?,
       ~activeOpacity=?,
       ~focusedOpacity=?,
+      ~testID=?,
       ~tvParallaxProperties=?,
     ) =>
   ReasonReact.wrapJsForReason(
@@ -83,6 +84,7 @@ let make =
         ),
       "focusedOpacity": focusedOpacity,
       "activeOpacity": activeOpacity,
+      "testID": testID,
       "tvParallaxProperties": tvParallaxProperties,
     },
   );

--- a/src/components/touchableOpacity.rei
+++ b/src/components/touchableOpacity.rei
@@ -1,4 +1,3 @@
-
 /**
 
 A wrapper for making views respond properly to touches. On press down, the opacity of the wrapped view is decreased, dimming it.
@@ -28,7 +27,6 @@ You can read more on [TouchableOpacity] component usage in official docs: {{:htt
     setOpacityTo: (ReasonReact.reactRef, float, int) => unit
   ]}
   */
-
 
 let make:
   (
@@ -77,6 +75,7 @@ let make:
     ~pressRetentionOffset: Types.insets=?,
     ~activeOpacity: float=?,
     ~focusedOpacity: float=?,
+    ~testID: string=?,
     ~tvParallaxProperties: Js.t({.})=?,
     array(ReasonReact.reactElement)
   ) =>

--- a/src/components/touchableWithoutFeedback.re
+++ b/src/components/touchableWithoutFeedback.re
@@ -19,6 +19,7 @@ let make =
       ~onPressOut=?,
       ~pressRetentionOffset=?,
       ~style=?,
+      ~testID=?,
     ) =>
   ReasonReact.wrapJsForReason(
     ~reactClass=view,
@@ -74,5 +75,6 @@ let make =
           },
           accessibilityTraits,
         ),
+      "testID": testID,
     },
   );

--- a/src/components/touchableWithoutFeedback.rei
+++ b/src/components/touchableWithoutFeedback.rei
@@ -64,7 +64,7 @@ You can read more on [TouchableWithoutFeedback] component usage in official docs
   {[
     ~hitSlop: Types.insets=?
   ]}
-  reference: 
+  reference:
   {4 Types.rei}
   {[
     type insets = {
@@ -79,7 +79,7 @@ You can read more on [TouchableWithoutFeedback] component usage in official docs
   {[
     ~onLayout: RNEvent.NativeLayoutEvent.t => unit=?
   ]}
-  reference: 
+  reference:
   {[
     module NativeLayoutEvent: {
       type t;
@@ -125,6 +125,10 @@ You can read more on [TouchableWithoutFeedback] component usage in official docs
   {4 style}
   {[
     ~style: Style.t=?
+  ]}
+  {4 testID}
+  {[
+    ~testID: string=?
   ]}
  */
 
@@ -173,6 +177,7 @@ let make:
     ~onPressOut: unit => unit=?,
     ~pressRetentionOffset: Types.insets=?,
     ~style: Style.t=?,
+    ~testID: string=?,
     array(ReasonReact.reactElement)
   ) =>
   ReasonReact.component(


### PR DESCRIPTION
Official ReactNative documentation does not mention `testID` on `Touchable` components but TypeScript definitions have it.