### PR TITLE
Fix onChange event type for TextInput

### DIFF
--- a/src/components/textInput.rei
+++ b/src/components/textInput.rei
@@ -358,7 +358,15 @@ let make:
     ~maxLength: int=?,
     ~multiline: bool=?,
     ~onBlur: unit => unit=?,
-    ~onChange: unit => unit=?,
+    ~onChange: {
+                 .
+                 "nativeEvent": {
+                   .
+                   "text": string,
+                   "target": int,
+                   "eventCount": int,
+                 },
+               } => unit=?,
     ~onChangeText: string => unit=?,
     ~onContentSizeChange: {
                             .


### PR DESCRIPTION
It was a bit hard to find but here's the code which dispatches this event.

https://github.com/facebook/react-native/blob/master/Libraries/Text/TextInput/RCTBaseTextInputView.m#L375-L379

cc @drager