### PR TITLE
Remove justifyContent(Stretch), it's unsupported by Yoga

### DIFF
--- a/lib/js/src/style.js
+++ b/lib/js/src/style.js
@@ -245,12 +245,9 @@ function justifyContent(v) {
         tmp = "center";
         break;
     case 3 : 
-        tmp = "stretch";
-        break;
-    case 4 : 
         tmp = "space-around";
         break;
-    case 5 : 
+    case 4 : 
         tmp = "space-between";
         break;
     

--- a/src/style.re
+++ b/src/style.re
@@ -213,7 +213,6 @@ type justifyContent =
   | FlexStart
   | FlexEnd
   | Center
-  | Stretch
   | SpaceAround
   | SpaceBetween;
 
@@ -224,7 +223,6 @@ let justifyContent = v =>
     | FlexStart => "flex-start"
     | FlexEnd => "flex-end"
     | Center => "center"
-    | Stretch => "stretch"
     | SpaceAround => "space-around"
     | SpaceBetween => "space-between"
     },

--- a/src/style.rei
+++ b/src/style.rei
@@ -73,7 +73,6 @@ type justifyContent =
   | FlexStart
   | FlexEnd
   | Center
-  | Stretch
   | SpaceAround
   | SpaceBetween;
 let justifyContent: justifyContent => styleElement;


### PR DESCRIPTION
Closes #306 if we think that's the right decision to remove it until that's really supported.