### PR TITLE
Exit docs build script if odoc is missing

### DIFF
--- a/docs/scripts/build-docs.sh
+++ b/docs/scripts/build-docs.sh
@@ -3,9 +3,13 @@
 PKG=BsReactNative
 
 DOCS=docs
-ODOC=$(which odoc)
 LIB=./lib/bs/src
 PAGES=./docs/pages
+ODOC=$(which odoc)
+if [[ $? != 0 ]] ; then
+  echo "Missing odoc, please look at the CONTRIBUTING.md guide"
+  exit 1
+fi
 
 # Gather the sources to compile .odoc files
 CMT_FILES=$(find ${LIB} -name "*.cmti")


### PR DESCRIPTION
The idea is to prevent tons of "Command does not exist" error & point to the right place on the required dependencies.
When they contribute, I guess lots of people (including me) just get a repo, do `yarn && yarn test` to see if everything is fine.
Currently with the repo, you gets tons or error if you blindly do that. This little modification ensure that `odoc` has been installed & warn+exit otherwise.