### PR TITLE
Add opam requirement (and the right version) to contributing notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ Documentation is generated from the Reason interface and comments that are inclu
 
 To start working with documentation:
 
-- Ensure that have the odoc installed [odoc](https://github.com/ocaml/odoc)
+- Ensure that have [opam](http://opam.ocaml.org/doc/Install.html) & use `opam switch create 4.02.3+buckle-master`.
+- Ensure that have [odoc](https://github.com/ocaml/odoc) installed.
   > if you have a problem during installing the odoc with OCaml dependencies, try: `opam pin add odoc.dev git+https://github.com/ocaml/odoc`
 - build code with: `yarn clean-build` or if you want to build with watch then use: `yarn start`
 - start docs server using: `yarn start-docs`. Script will run the HTTP server and reload after something changes.


### PR DESCRIPTION
Because it's a missing information I struggled to find (I found this in CI configuration).