### PR TITLE
Support "flex-basis: auto" as it's valid & Yoga ready

### DIFF
--- a/lib/js/src/style.js
+++ b/lib/js/src/style.js
@@ -184,7 +184,7 @@ function flex(param) {
 function flexBasis(value) {
   return /* tuple */[
           "flexBasis",
-          encode_pt_pct(value)
+          encode_pt_pct_auto(value)
         ];
 }
 

--- a/src/style.re
+++ b/src/style.re
@@ -173,7 +173,7 @@ let display = v =>
 
 let flex = floatStyle("flex");
 
-let flexBasis = value => ("flexBasis", encode_pt_pct(value));
+let flexBasis = value => ("flexBasis", encode_pt_pct_auto(value));
 
 type flexDirection =
   | Row

--- a/src/style.rei
+++ b/src/style.rei
@@ -56,7 +56,7 @@ type display =
   | None;
 let display: display => styleElement;
 let flex: float => styleElement;
-let flexBasis: pt_pct => styleElement;
+let flexBasis: pt_pct_auto => styleElement;
 type flexDirection =
   | Row
   | RowReverse


### PR DESCRIPTION
It's supported by css & yoga
- https://yogalayout.com/docs/flex
- https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis

That's the default value, but if you do flex(1.) & want to put back flexBasis to Auto, you need this change/fix!