### PR TITLE
Zero cost bindings for style merge (array/list)

### DIFF
--- a/bs-react-native-example/src/pages/ViewExample.re
+++ b/bs-react-native-example/src/pages/ViewExample.re
@@ -106,7 +106,7 @@ module ZIndexExample = {
             {ReasonReact.string("Tap to flip sorting order")}
           </Text>
           <View
-            style={fromList([
+            style={list([
               styles##zIndex,
               style([
                 marginTop(Pt(0.)),
@@ -117,7 +117,7 @@ module ZIndexExample = {
             <Text> {ReasonReact.string(zIndexStr(0))} </Text>
           </View>
           <View
-            style={fromList([
+            style={list([
               styles##zIndex,
               style([
                 marginLeft(Pt(50.)),
@@ -128,7 +128,7 @@ module ZIndexExample = {
             <Text> {ReasonReact.string(zIndexStr(1))} </Text>
           </View>
           <View
-            style={fromList([
+            style={list([
               styles##zIndex,
               style([
                 marginLeft(Pt(100.)),
@@ -139,7 +139,7 @@ module ZIndexExample = {
             <Text> {ReasonReact.string(zIndexStr(2))} </Text>
           </View>
           <View
-            style={fromList([
+            style={list([
               styles##zIndex,
               style([
                 marginLeft(Pt(150.)),
@@ -204,19 +204,18 @@ let examples: array(Example.t) =
               borderColor(String("#bb0000")),
               borderWidth(1.),
             ])}>
-            <View
-              style={fromList([styles##box, style([padding(Pt(5.))])])}>
+            <View style={list([styles##box, style([padding(Pt(5.))])])}>
               <Text style={style([fontSize(Float(11.))])}>
                 {ReasonReact.string("5px padding")}
               </Text>
             </View>
-            <View style={fromList([styles##box, style([margin(Pt(5.))])])}>
+            <View style={list([styles##box, style([margin(Pt(5.))])])}>
               <Text style={style([fontSize(Float(11.))])}>
                 {ReasonReact.string("5px margin")}
               </Text>
             </View>
             <View
-              style={fromList([
+              style={list([
                 styles##box,
                 style([
                   margin(Pt(5.)),

--- a/bs-react-native-next/src/Style.re
+++ b/bs-react-native-next/src/Style.re
@@ -252,11 +252,6 @@ external style:
   t =
   "";
 
-[@deprecated "Use Style.array([|t|]) instead"]
-[@bs.module "react-native"]
-[@bs.scope "StyleSheet"]
-external flatten: array(t) => t = "";
-
 external array: array(t) => t = "%identity";
 external arrayOption: array(option(t)) => t = "%identity";
 external list: list(t) => t = "%identity";

--- a/bs-react-native-next/src/Style.re
+++ b/bs-react-native-next/src/Style.re
@@ -252,6 +252,12 @@ external style:
   t =
   "";
 
-// Duplicated from StyleSheet.re for convenience.
-[@bs.module "react-native"] [@bs.scope "StyleSheet"]
+[@deprecated "Use Style.array([|t|]) instead"]
+[@bs.module "react-native"]
+[@bs.scope "StyleSheet"]
 external flatten: array(t) => t = "";
+
+external array: array(t) => t = "%identity";
+external arrayOption: array(option(t)) => t = "%identity";
+external list: list(t) => t = "%identity";
+external listOption: list(option(t)) => t = "%identity";

--- a/bs-react-native-next/src/Style.re
+++ b/bs-react-native-next/src/Style.re
@@ -252,7 +252,39 @@ external style:
   t =
   "";
 
+/*
+ <View style=array([|
+   styles##thing,
+   styles##whatever,
+ |])>
+   */
 external array: array(t) => t = "%identity";
+
+/*
+ <View style=arrayOption([|
+   Some(styles##thing),
+   Some(styles##whatever),
+   optionalStyle,
+   cond ? Some({something:"dynamic"}) : None
+ |])>
+ */
 external arrayOption: array(option(t)) => t = "%identity";
+
+/* list works too since RN accept recursive array of styles (list are just recursive arrays)*/
+/*
+ <View style=list([
+   styles##thing,
+   styles##whatever,
+ ])>
+   */
 external list: list(t) => t = "%identity";
+
+/*
+ <View style=listOption([
+   Some(styles##thing),
+   Some(styles##whatever),
+   optionalStyle,
+   cond ? Some({something:"dynamic"}) : None
+ ])>
+ */
 external listOption: list(option(t)) => t = "%identity";

--- a/bs-react-native/src/style.bs.js
+++ b/bs-react-native/src/style.bs.js
@@ -46,26 +46,14 @@ function encode_deg_animated(param) {
 
 var style = Js_dict.fromList;
 
-var emptyStyle = { };
-
-var fromList = Belt_List.toArray;
-
-function merge(a, b) {
-  return Js_dict.fromArray($$Array.append(Js_dict.entries(a), Js_dict.entries(b)));
-}
-
-function mergeOptional(s, so) {
-  return Belt_Option.getWithDefault(Belt_Option.map(so, (function (so) {
-                    return merge(s, so);
-                  })), s);
-}
-
-function optional(s) {
-  return Belt_Option.getWithDefault(s, emptyStyle);
-}
-
 function flatten(prim) {
   return prim;
+}
+
+var concat = Belt_List.toArray;
+
+function combine(a, b) {
+  return Js_dict.fromArray($$Array.append(Js_dict.entries(a), Js_dict.entries(b)));
 }
 
 function alignContent(v) {
@@ -1125,11 +1113,21 @@ function overlayColor(value) {
         ];
 }
 
-var combine = merge;
+function array(prim) {
+  return prim;
+}
 
-var concat = fromList;
+function arrayOption(prim) {
+  return prim;
+}
 
-var combineOptional = mergeOptional;
+function list(prim) {
+  return prim;
+}
+
+function listOption(prim) {
+  return prim;
+}
 
 var Transform = [
   perspective,
@@ -1150,14 +1148,13 @@ var Transform = [
 
 export {
   style ,
-  fromList ,
-  merge ,
-  mergeOptional ,
-  optional ,
+  array ,
+  arrayOption ,
+  list ,
+  listOption ,
   flatten ,
-  combine ,
   concat ,
-  combineOptional ,
+  combine ,
   alignContent ,
   alignItems ,
   alignSelf ,

--- a/bs-react-native/src/style.re
+++ b/bs-react-native/src/style.re
@@ -81,11 +81,16 @@ let objectStyle = (key, value) => (key, Internals.Encoder.object_(value));
 let arrayStyle = (key, value) => (key, Internals.Encoder.array(value));
 
 let style = sarr => sarr |> Js.Dict.fromList |> to_style;
-let emptyStyle = Js.Dict.empty()->to_style;
 
-external fromArray: array(t) => t = "%identity";
-let fromList = styles => styles->Belt.List.toArray->arrayOfStyle;
-let merge = (a, b) => {
+external array: array(t) => t = "%identity";
+external arrayOption: array(option(t)) => t = "%identity";
+external list: list(t) => t = "%identity";
+external listOption: list(option(t)) => t = "%identity";
+
+/* deprecated */
+let flatten = array;
+let concat = styles => styles->Belt.List.toArray->arrayOfStyle;
+let combine = (a, b) => {
   let entries =
     Array.append(
       Js.Dict.entries(style_to_dict(a)),
@@ -93,15 +98,6 @@ let merge = (a, b) => {
     );
   Js.Dict.fromArray(entries) |> to_style;
 };
-let mergeOptional = (s, so) =>
-  so->Belt.Option.map(so => s->merge(so))->Belt.Option.getWithDefault(s);
-let optional = s => s->Belt.Option.getWithDefault(emptyStyle);
-
-/* deprecated */
-let flatten = fromArray;
-let concat = fromList;
-let combine = merge;
-let combineOptional = mergeOptional;
 
 /***
  * Layout Props

--- a/bs-react-native/src/style.rei
+++ b/bs-react-native/src/style.rei
@@ -25,20 +25,48 @@ type deg_animated('a) =
   | Animated(AnimatedRe.value('a));
 
 let style: list(styleElement) => t;
-external fromArray: array(t) => t = "%identity";
-let fromList: list(t) => t;
-let merge: (t, t) => t;
-let mergeOptional: (t, option(t)) => t;
-let optional: option(t) => t;
 
-[@deprecated "use Style.fromArray([|t|]) instead"]
+/*
+ <View style=mix([|
+   styles##thing,
+   styles##whatever,
+ |])>
+   */
+let array: array(t) => t;
+/*
+ <View style=arrayOption([|
+   Some(styles##thing),
+   Some(styles##whatever),
+   optionalStyle,
+   cond ? {something:"dynamic"} : None
+ |])>
+ */
+let arrayOption: array(option(t)) => t;
+/* list works too since RN accept recursive array of styles (list are just recursive arrays)*/
+/*
+ <View style=list([
+   styles##thing,
+   styles##whatever,
+ ])>
+   */
+let list: list(t) => t;
+/*
+ <View style=listOption([
+   Some(styles##thing),
+   Some(styles##whatever),
+   optionalStyle,
+   cond ? {something:"dynamic"} : None
+ ])>
+ */
+let listOption: list(option(t)) => t;
+[@deprecated "Use Style.array([|t|]) instead"]
 let flatten: array(t) => t;
-[@deprecated "use Style.merge(t, t) instead"]
-let combine: (t, t) => t;
-[@deprecated "use Style.fromList([t]) instead"]
+[@deprecated "Use Style.list([t]) instead"]
 let concat: list(t) => t;
-[@deprecated "use Style.mergeOptional(t, option(t)) instead"]
-let combineOptional: (t, option(t)) => t;
+[@deprecated
+  "This method is unsafe as it doesn't work well with StyleSheet values."
+]
+let combine: (t, t) => t;
 
 type alignContent =
   | FlexStart

--- a/bs-react-native/src/style.rei
+++ b/bs-react-native/src/style.rei
@@ -27,7 +27,7 @@ type deg_animated('a) =
 let style: list(styleElement) => t;
 
 /*
- <View style=mix([|
+ <View style=array([|
    styles##thing,
    styles##whatever,
  |])>
@@ -38,7 +38,7 @@ let array: array(t) => t;
    Some(styles##thing),
    Some(styles##whatever),
    optionalStyle,
-   cond ? {something:"dynamic"} : None
+   cond ? Some({something:"dynamic"}) : None
  |])>
  */
 let arrayOption: array(option(t)) => t;
@@ -55,7 +55,7 @@ let list: list(t) => t;
    Some(styles##thing),
    Some(styles##whatever),
    optionalStyle,
-   cond ? {something:"dynamic"} : None
+   cond ? Some({something:"dynamic"}) : None
  ])>
  */
 let listOption: list(option(t)) => t;


### PR DESCRIPTION
RN accept works out of the box array of styles (object|int from StyleSheet entries|false|null|undefined).
It also recursively resolve the array of styles, so list should work too (as list are just recursive array).

I tried to find a "smart" name but at the end, using merge/flatten/combine/concat just make this more confusing...

This PR
- deprecate all previous confusing names method
- add array/list free binding
- add also array/listOption as those are free to, & convenient when you conditionally mix styles(since RN accepts undefined & that None is encoded as undefined...)
- deprecate combine/merge as this is totally unsafe IRL (you cannot merge object of style with a stylesheet entry, which works with current types...)

Thoughts? Idea for better naming?