### PR TITLE
bs-react-native-next: Add Image methods

### DIFF
--- a/bs-react-native-next/src/components/Image.re
+++ b/bs-react-native-next/src/components/Image.re
@@ -1,31 +1,34 @@
+type uriSource;
+
+[@bs.obj]
+external uriSource:
+  (
+    ~uri: string,
+    ~bundle: string=?,
+    ~method: string=?,
+    ~headers: Js.t('a)=?,
+    ~body: string=?,
+    ~cache: [@bs.string] [
+              | `default
+              | `reload
+              | [@bs.as "force-cache"] `forceCache
+              | [@bs.as "only-if-cached"] `onlyIfCached
+            ]
+              =?,
+    ~scale: float=?,
+    ~width: float=?,
+    ~height: float=?,
+    unit
+  ) =>
+  uriSource =
+  "";
+
 module Source = {
   type t;
 
-  [@bs.obj]
-  external fromUri:
-    (
-      ~uri: string,
-      ~bundle: string=?,
-      ~method: string=?,
-      ~headers: Js.t('a)=?,
-      ~body: string=?,
-      ~cache: [@bs.string] [
-                | `default
-                | `reload
-                | `forceCache
-                | `onlyIfCached
-              ]
-                =?,
-      ~scale: float=?,
-      ~width: float=?,
-      ~height: float=?,
-      unit
-    ) =>
-    t =
-    "";
-
   external fromRequired: Packager.required => t = "%identity";
-  external fromArray: array(t) => t = "%identity";
+  external fromUriSource: uriSource => t = "%identity";
+  external fromUriSources: array(uriSource) => t = "%identity";
 };
 
 module DefaultSource = {
@@ -75,3 +78,31 @@ external make:
   ) =>
   React.element =
   "Image";
+
+type error;
+
+[@bs.module "react-native"] [@bs.scope "Image"]
+external getSize:
+  (
+    ~uri: string,
+    ~success: (~width: float, ~height: float) => unit,
+    ~failure: error => unit=?,
+    unit
+  ) =>
+  unit =
+  "getSize";
+
+type requestId;
+
+[@bs.module "react-native"] [@bs.scope "Image"]
+external prefetch: (~uri: string) => requestId = "prefetch";
+
+[@bs.module "react-native"] [@bs.scope "Image"]
+external abortPrefetch: requestId => unit = "abortPrefetch";
+
+[@bs.module "react-native"] [@bs.scope "Image"]
+external queryCache: (~uris: array(string)) => unit = "queryCache";
+
+[@bs.module "react-native"] [@bs.scope "Image"]
+external resolveAssetSource: Packager.required => uriSource =
+  "resolveAssetSource";


### PR DESCRIPTION
Also fixed the cache enums with [@bs.as].

Concerning `resolveAssetSource`: You can look up in the [RN code](https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/Libraries/Image/resolveAssetSource.js#L88), that this method does not do anything for a source that isn't a number (or `Packager.required` here) and does not make sense in a strongly typed language (it is just there if you do not know whether your source is from a `require` statement or a source object (for instance when you want to write some image handling library).