### PR TITLE
Bugfix: correct type for the trackColor prop [Switch component]

### DIFF
--- a/bs-react-native-next/src/components/Switch.re
+++ b/bs-react-native-next/src/components/Switch.re
@@ -1,8 +1,15 @@
+type trackColor;
+[@bs.obj] external trackColor: (
+  ~_true: Style.color=?,
+  ~_false: Style.color=?,
+  unit
+) => trackColor = "";
+
 [@react.component] [@bs.module "react-native"]
 external make:
   (
     ~disabled: bool=?,
-    ~trackColor: Style.color=?,
+    ~trackColor: trackColor=?,
     ~ios_backgroundColor: Style.color=?,
     ~onValueChange: bool => unit=?,
     ~thumbColor: Style.color=?,


### PR DESCRIPTION
Very simple bug fix since the `trackColor` prop requires an object of type `{false: color, true: color}` and not simply `color`. The spec calls for a `null` as the default value for either field if no color is supplied.

Accordingly, this PR does not actually produce the correct JS object when either argument (or both) is not supplied, but there are no runtime errors and everything works correctly.