### PR TITLE
Fix refs.

### DIFF
--- a/bs-react-native-next/src/components/FlatList.md
+++ b/bs-react-native-next/src/components/FlatList.md
@@ -190,7 +190,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -227,7 +227,7 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";
 ```

--- a/bs-react-native-next/src/components/FlatList.re
+++ b/bs-react-native-next/src/components/FlatList.re
@@ -183,7 +183,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -220,6 +220,6 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";

--- a/bs-react-native-next/src/components/ScrollView.md
+++ b/bs-react-native-next/src/components/ScrollView.md
@@ -150,10 +150,10 @@ type scrollToEndOptions;
 external scrollToEndOptions:
   (~animated: bool=?, ~duration: float=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";
 ```

--- a/bs-react-native-next/src/components/ScrollView.re
+++ b/bs-react-native-next/src/components/ScrollView.re
@@ -143,9 +143,9 @@ type scrollToEndOptions;
 external scrollToEndOptions:
   (~animated: bool=?, ~duration: float=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";

--- a/bs-react-native-next/src/components/SectionList.md
+++ b/bs-react-native-next/src/components/SectionList.md
@@ -192,7 +192,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -229,8 +229,8 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";
 
 ```

--- a/bs-react-native-next/src/components/SectionList.re
+++ b/bs-react-native-next/src/components/SectionList.re
@@ -185,7 +185,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -222,6 +222,6 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";

--- a/bs-react-native-next/src/components/TextInput.md
+++ b/bs-react-native-next/src/components/TextInput.md
@@ -5,6 +5,9 @@ wip: true
 ---
 
 ```reason
+type element;
+type ref = React.Ref.t(Js.nullable(element));
+
 type event('a) = {. "nativeEvent": 'a};
 
 type editingEvent =
@@ -50,6 +53,8 @@ type keyPressEvent = event({. "key": string});
 [@react.component] [@bs.module "react-native"]
 external make:
   (
+    ~ref: ref=?,
+    // TextInput props
     ~allowFontScaling: bool=?,
     ~autoCapitalize: [@bs.string] [
                        | `characters
@@ -279,12 +284,12 @@ external make:
   React.element =
   "TextInput";
 
-[@bs.send] external isFocused: ReasonReact.reactRef => bool = "";
+[@bs.send] external isFocused: element => bool = "";
 
-[@bs.send] external clear: ReasonReact.reactRef => unit = "";
+[@bs.send] external clear: element => unit = "";
 
-[@bs.send] external focus: ReasonReact.reactRef => unit = "";
+[@bs.send] external focus: element => unit = "";
 
-[@bs.send] external blur: ReasonReact.reactRef => unit = "";
+[@bs.send] external blur: element => unit = "";
 
 ```

--- a/bs-react-native-next/src/components/TextInput.re
+++ b/bs-react-native-next/src/components/TextInput.re
@@ -277,10 +277,10 @@ external make:
   React.element =
   "TextInput";
 
-[@bs.send] external isFocused: ref => bool = "";
+[@bs.send] external isFocused: element => bool = "";
 
-[@bs.send] external clear: ref => unit = "";
+[@bs.send] external clear: element => unit = "";
 
-[@bs.send] external focus: ref => unit = "";
+[@bs.send] external focus: element => unit = "";
 
-[@bs.send] external blur: ref => unit = "";
+[@bs.send] external blur: element => unit = "";

--- a/bs-react-native-next/src/components/VirtualizedList.md
+++ b/bs-react-native-next/src/components/VirtualizedList.md
@@ -243,7 +243,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -280,7 +280,7 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";
 ```

--- a/bs-react-native-next/src/components/VirtualizedList.re
+++ b/bs-react-native-next/src/components/VirtualizedList.re
@@ -236,7 +236,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -273,6 +273,6 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";

--- a/bs-react-native-next/src/components/VirtualizedSectionList.md
+++ b/bs-react-native-next/src/components/VirtualizedSectionList.md
@@ -206,7 +206,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -243,7 +243,7 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";
 ```

--- a/bs-react-native-next/src/components/VirtualizedSectionList.re
+++ b/bs-react-native-next/src/components/VirtualizedSectionList.re
@@ -199,7 +199,7 @@ type scrollToEndOptions;
 [@bs.obj]
 external scrollToEndOptions: (~animated: bool=?, unit) => scrollToEndOptions =
   "";
-[@bs.send] external scrollToEnd: ref => unit = "scrollToEnd";
+[@bs.send] external scrollToEnd: element => unit = "scrollToEnd";
 [@bs.send]
 external scrollToEndWithOptions: (ref, scrollToEndOptions) => unit =
   "scrollToEnd";
@@ -236,6 +236,6 @@ external scrollToOffsetParams:
 [@bs.send]
 external scrollToOffset: scrollToOffsetParams => unit = "scrollToOffset";
 
-[@bs.send] external recordInteraction: ref => unit = "";
+[@bs.send] external recordInteraction: element => unit = "";
 
-[@bs.send] external flashScrollIndicators: ref => unit = "";
+[@bs.send] external flashScrollIndicators: element => unit = "";


### PR DESCRIPTION
We added a TextInput to our app and discovered that I had modelled refs incorrectly. 😱

Having

```re
type element;
type ref = React.Ref.t(Js.nullable(element));
```

and

```re
[@react.component] [@bs.module "react-native"]
external make:
  (
    ~ref: ref=?,
    ...
```

we need to have

```re
[@bs.send] external focus: element => unit = "";
```

not

```re
[@bs.send] external focus: ref => unit = "";
```