### PR TITLE
Fix Image.resolveAssetSource return type

### DIFF
--- a/bs-react-native-next/src/components/Image.md
+++ b/bs-react-native-next/src/components/Image.md
@@ -110,8 +110,15 @@ external abortPrefetch: requestId => unit = "abortPrefetch";
 [@bs.module "react-native"] [@bs.scope "Image"]
 external queryCache: (~uris: array(string)) => unit = "queryCache";
 
+type asset = {
+  .
+  "uri": string,
+  "width": float,
+  "height": float,
+};
+
 [@bs.module "react-native"] [@bs.scope "Image"]
-external resolveAssetSource: Packager.required => uriSource =
+external resolveAssetSource: Packager.required => asset =
   "resolveAssetSource";
 
 ```

--- a/bs-react-native-next/src/components/Image.re
+++ b/bs-react-native-next/src/components/Image.re
@@ -103,6 +103,12 @@ external abortPrefetch: requestId => unit = "abortPrefetch";
 [@bs.module "react-native"] [@bs.scope "Image"]
 external queryCache: (~uris: array(string)) => unit = "queryCache";
 
+type asset = {
+  .
+  "uri": string,
+  "width": float,
+  "height": float,
+};
+
 [@bs.module "react-native"] [@bs.scope "Image"]
-external resolveAssetSource: Packager.required => uriSource =
-  "resolveAssetSource";
+external resolveAssetSource: Source.t => asset = "resolveAssetSource";


### PR DESCRIPTION
According to official doc (& experience), an object is returned. That's something I use often when playing with image  to resize those & keep ratio (by doing basic math with width & height).
If we return Source.t, we cannot do anything with it.