### PR TITLE
Remove unit from cropImage arguments

### DIFF
--- a/bs-react-native-next/src/apis/ImageEditor.md
+++ b/bs-react-native-next/src/apis/ImageEditor.md
@@ -38,8 +38,7 @@ external cropImage:
     ~uri: source,
     ~cropData: cropData,
     ~success: string => unit,
-    ~failure: (~code: int, ~message: string) => unit,
-    unit
+    ~failure: (~code: int, ~message: string) => unit
   ) =>
   unit =
   "cropImage";

--- a/bs-react-native-next/src/apis/ImageEditor.re
+++ b/bs-react-native-next/src/apis/ImageEditor.re
@@ -31,8 +31,7 @@ external cropImage:
     ~uri: source,
     ~cropData: cropData,
     ~success: string => unit,
-    ~failure: (~code: int, ~message: string) => unit,
-    unit
+    ~failure: (~code: int, ~message: string) => unit
   ) =>
   unit =
   "cropImage";


### PR DESCRIPTION
I had intended for the `failure` callback to be optional (hence `unit` at the end), but neglected to remove `unit` after making it required.