### PR TITLE
Zero-cost binding for Animated.loop

### DIFF
--- a/bs-react-native-next/src/apis/Animated.bs.js
+++ b/bs-react-native-next/src/apis/Animated.bs.js
@@ -49,13 +49,6 @@ var ValueXY = /* module */[
   /* Timing */Timing$1
 ];
 
-function loop($staropt$star, animation, param) {
-  var iterations = $staropt$star !== undefined ? $staropt$star : -1;
-  return ReactNative.Animated.loop(animation, {
-              iterations: iterations
-            });
-}
-
 function timing(prim, prim$1) {
   return ReactNative.Animated.timing(prim, prim$1);
 }
@@ -89,7 +82,6 @@ exports.Interpolation = Interpolation;
 exports.ValueOperations = ValueOperations;
 exports.Value = Value;
 exports.ValueXY = ValueXY;
-exports.loop = loop;
 exports.timing = timing;
 exports.spring = spring;
 exports.decay = decay;

--- a/bs-react-native-next/src/apis/Animated.md
+++ b/bs-react-native-next/src/apis/Animated.md
@@ -244,10 +244,9 @@ external parallel:
 external stagger: (float, array(Animation.t)) => Animation.t = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external _loop: (Animation.t, {. "iterations": int}) => Animation.t = "loop";
-
-let loop = (~iterations=(-1), ~animation, ()) =>
-  _loop(animation, {"iterations": iterations});
+external loop:
+  (Animation.t, ~config: {. "iterations": int}=?, unit) => Animation.t =
+  "";
 
 type animatedEvent;
 
@@ -270,5 +269,6 @@ let start = Animation.start;
 let stop = Animation.stop;
 
 let reset = Animation.reset;
+
 
 ```

--- a/bs-react-native-next/src/apis/Animated.md
+++ b/bs-react-native-next/src/apis/Animated.md
@@ -243,10 +243,12 @@ external parallel:
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external stagger: (float, array(Animation.t)) => Animation.t = "";
 
+type loopConfig;
+
+[@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
+
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external loop:
-  (Animation.t, ~config: {. "iterations": int}=?, unit) => Animation.t =
-  "";
+external loop: (Animation.t, loopConfig) => Animation.t = "";
 
 type animatedEvent;
 
@@ -269,6 +271,5 @@ let start = Animation.start;
 let stop = Animation.stop;
 
 let reset = Animation.reset;
-
 
 ```

--- a/bs-react-native-next/src/apis/Animated.md
+++ b/bs-react-native-next/src/apis/Animated.md
@@ -248,7 +248,10 @@ type loopConfig;
 [@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external loop: (Animation.t, loopConfig) => Animation.t = "";
+external loop: Animation.t => Animation.t = "";
+
+[@bs.module "react-native"] [@bs.scope "Animated"]
+external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "";
 
 type animatedEvent;
 

--- a/bs-react-native-next/src/apis/Animated.re
+++ b/bs-react-native-next/src/apis/Animated.re
@@ -241,7 +241,10 @@ type loopConfig;
 [@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external loop: (Animation.t, loopConfig) => Animation.t = "";
+external loop: Animation.t => Animation.t = "";
+
+[@bs.module "react-native"] [@bs.scope "Animated"]
+external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "";
 
 type animatedEvent;
 

--- a/bs-react-native-next/src/apis/Animated.re
+++ b/bs-react-native-next/src/apis/Animated.re
@@ -236,10 +236,12 @@ external parallel:
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external stagger: (float, array(Animation.t)) => Animation.t = "";
 
+type loopConfig;
+
+[@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
+
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external loop:
-  (Animation.t, ~config: {. "iterations": int}=?, unit) => Animation.t =
-  "";
+external loop: (Animation.t, loopConfig) => Animation.t = "";
 
 type animatedEvent;
 

--- a/bs-react-native-next/src/apis/Animated.re
+++ b/bs-react-native-next/src/apis/Animated.re
@@ -237,10 +237,9 @@ external parallel:
 external stagger: (float, array(Animation.t)) => Animation.t = "";
 
 [@bs.module "react-native"] [@bs.scope "Animated"]
-external _loop: (Animation.t, {. "iterations": int}) => Animation.t = "loop";
-
-let loop = (~iterations=(-1), ~animation, ()) =>
-  _loop(animation, {"iterations": iterations});
+external loop:
+  (Animation.t, ~config: {. "iterations": int}=?, unit) => Animation.t =
+  "";
 
 type animatedEvent;
 


### PR DESCRIPTION
I did not want to implement this without investigation the default value provided (-1). Without the config object, the default value is already assumed to be -1 (which means infinite loop), so there is no need for the binding to provide the default value.
