### PR TITLE
Zero-cost bindings to ImagePickerIOS

### DIFF
--- a/bs-react-native-next/src/apis/ImagePickerIOS.bs.js
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/bs-react-native-next/src/apis/ImagePickerIOS.md
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.md
@@ -13,10 +13,30 @@ external canUseCamera: (bool => unit) => unit = "";
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external canRecordVideos: (bool => unit) => unit = "";
 
+type cameraDialogConfig;
+[@bs.obj]
+external cameraDialogConfig:
+  (
+    ~videoMode: bool
+  ) =>
+  cameraDialogConfig =
+  "";
+
+type selectDialogConfig;
+[@bs.obj]
+external selectDialogConfig:
+  (
+    ~showImages: bool,
+    ~showVideos: bool
+  ) =>
+  selectDialogConfig =
+  "";
+
+
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openCameraDialog:
   (
-    {. "videoMode": bool},
+    ~config: cameraDialogConfig=?,
     ~onSuccess: imageUri => unit,
     ~onError: 'error => unit
   ) =>
@@ -26,13 +46,10 @@ external openCameraDialog:
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openSelectDialog:
   (
-    {
-      .
-      "showImages": bool,
-      "showVideos": bool,
-    },
+    ~config: selectDialogConfig=?,
     ~onSuccess: imageUri => unit,
-    ~onError: 'error => unit
+    ~onError: 'error => unit,
+    unit
   ) =>
   unit =
   "";

--- a/bs-react-native-next/src/apis/ImagePickerIOS.md
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.md
@@ -15,12 +15,13 @@ external canRecordVideos: (bool => unit) => unit = "";
 
 type cameraDialogConfig;
 [@bs.obj]
-external cameraDialogConfig: (~videoMode: bool=?) => cameraDialogConfig = "";
+external cameraDialogConfig: (~videoMode: bool=?, unit) => cameraDialogConfig =
+  "";
 
 type selectDialogConfig;
 [@bs.obj]
 external selectDialogConfig:
-  (~showImages: bool=?, ~showVideos: bool=?) => selectDialogConfig =
+  (~showImages: bool=?, ~showVideos: bool=?, unit) => selectDialogConfig =
   "";
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]

--- a/bs-react-native-next/src/apis/ImagePickerIOS.md
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.md
@@ -15,28 +15,18 @@ external canRecordVideos: (bool => unit) => unit = "";
 
 type cameraDialogConfig;
 [@bs.obj]
-external cameraDialogConfig:
-  (
-    ~videoMode: bool
-  ) =>
-  cameraDialogConfig =
-  "";
+external cameraDialogConfig: (~videoMode: bool=?) => cameraDialogConfig = "";
 
 type selectDialogConfig;
 [@bs.obj]
 external selectDialogConfig:
-  (
-    ~showImages: bool,
-    ~showVideos: bool
-  ) =>
-  selectDialogConfig =
+  (~showImages: bool=?, ~showVideos: bool=?) => selectDialogConfig =
   "";
-
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openCameraDialog:
   (
-    ~config: cameraDialogConfig=?,
+    ~config: cameraDialogConfig,
     ~onSuccess: imageUri => unit,
     ~onError: 'error => unit
   ) =>
@@ -46,10 +36,9 @@ external openCameraDialog:
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openSelectDialog:
   (
-    ~config: selectDialogConfig=?,
+    ~config: selectDialogConfig,
     ~onSuccess: imageUri => unit,
-    ~onError: 'error => unit,
-    unit
+    ~onError: 'error => unit
   ) =>
   unit =
   "";

--- a/bs-react-native-next/src/apis/ImagePickerIOS.md
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.md
@@ -1,0 +1,40 @@
+---
+id: apis/ImagePickerIOS
+title: ImagePickerIOS
+wip: true
+---
+
+```reason
+type imageUri = string;
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external canUseCamera: (bool => unit) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external canRecordVideos: (bool => unit) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external openCameraDialog:
+  (
+    {. "videoMode": bool},
+    ~onSuccess: imageUri => unit,
+    ~onError: 'error => unit
+  ) =>
+  unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external openSelectDialog:
+  (
+    {
+      .
+      "showImages": bool,
+      "showVideos": bool,
+    },
+    ~onSuccess: imageUri => unit,
+    ~onError: 'error => unit
+  ) =>
+  unit =
+  "";
+
+```

--- a/bs-react-native-next/src/apis/ImagePickerIOS.re
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.re
@@ -6,10 +6,30 @@ external canUseCamera: (bool => unit) => unit = "";
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external canRecordVideos: (bool => unit) => unit = "";
 
+type cameraDialogConfig;
+[@bs.obj]
+external cameraDialogConfig:
+  (
+    ~videoMode: bool
+  ) =>
+  cameraDialogConfig =
+  "";
+
+type selectDialogConfig;
+[@bs.obj]
+external selectDialogConfig:
+  (
+    ~showImages: bool,
+    ~showVideos: bool
+  ) =>
+  selectDialogConfig =
+  "";
+
+
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openCameraDialog:
   (
-    {. "videoMode": bool},
+    ~config: cameraDialogConfig=?,
     ~onSuccess: imageUri => unit,
     ~onError: 'error => unit
   ) =>
@@ -19,13 +39,10 @@ external openCameraDialog:
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openSelectDialog:
   (
-    {
-      .
-      "showImages": bool,
-      "showVideos": bool,
-    },
+    ~config: selectDialogConfig=?,
     ~onSuccess: imageUri => unit,
-    ~onError: 'error => unit
+    ~onError: 'error => unit,
+    unit
   ) =>
   unit =
   "";

--- a/bs-react-native-next/src/apis/ImagePickerIOS.re
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.re
@@ -8,12 +8,13 @@ external canRecordVideos: (bool => unit) => unit = "";
 
 type cameraDialogConfig;
 [@bs.obj]
-external cameraDialogConfig: (~videoMode: bool=?) => cameraDialogConfig = "";
+external cameraDialogConfig: (~videoMode: bool=?, unit) => cameraDialogConfig =
+  "";
 
 type selectDialogConfig;
 [@bs.obj]
 external selectDialogConfig:
-  (~showImages: bool=?, ~showVideos: bool=?) => selectDialogConfig =
+  (~showImages: bool=?, ~showVideos: bool=?, unit) => selectDialogConfig =
   "";
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]

--- a/bs-react-native-next/src/apis/ImagePickerIOS.re
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.re
@@ -1,0 +1,31 @@
+type imageUri = string;
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external canUseCamera: (bool => unit) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external canRecordVideos: (bool => unit) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external openCameraDialog:
+  (
+    {. "videoMode": bool},
+    ~onSuccess: imageUri => unit,
+    ~onError: 'error => unit
+  ) =>
+  unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
+external openSelectDialog:
+  (
+    {
+      .
+      "showImages": bool,
+      "showVideos": bool,
+    },
+    ~onSuccess: imageUri => unit,
+    ~onError: 'error => unit
+  ) =>
+  unit =
+  "";

--- a/bs-react-native-next/src/apis/ImagePickerIOS.re
+++ b/bs-react-native-next/src/apis/ImagePickerIOS.re
@@ -8,28 +8,18 @@ external canRecordVideos: (bool => unit) => unit = "";
 
 type cameraDialogConfig;
 [@bs.obj]
-external cameraDialogConfig:
-  (
-    ~videoMode: bool
-  ) =>
-  cameraDialogConfig =
-  "";
+external cameraDialogConfig: (~videoMode: bool=?) => cameraDialogConfig = "";
 
 type selectDialogConfig;
 [@bs.obj]
 external selectDialogConfig:
-  (
-    ~showImages: bool,
-    ~showVideos: bool
-  ) =>
-  selectDialogConfig =
+  (~showImages: bool=?, ~showVideos: bool=?) => selectDialogConfig =
   "";
-
 
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openCameraDialog:
   (
-    ~config: cameraDialogConfig=?,
+    ~config: cameraDialogConfig,
     ~onSuccess: imageUri => unit,
     ~onError: 'error => unit
   ) =>
@@ -39,10 +29,9 @@ external openCameraDialog:
 [@bs.module "react-native"] [@bs.scope "ImagePickerIOS"]
 external openSelectDialog:
   (
-    ~config: selectDialogConfig=?,
+    ~config: selectDialogConfig,
     ~onSuccess: imageUri => unit,
-    ~onError: 'error => unit,
-    unit
+    ~onError: 'error => unit
   ) =>
   unit =
   "";


### PR DESCRIPTION
I discovered there were some errors with the legacy implementation, namely `canUseCamera` and `canRecordVideos` should take functions of type `bool => unit`.

Likewise `onSuccess` should take functions of type `string => unit` so that the image selected from the library or captured on camera can be acted upon.

Finally, perhaps it's due to only testing on the simulator,  but the type of the error is unclear. Hitting the `Cancel` button calls the `onError` callback, but I only get `undefined`. It's been previously specified as
```
type error = {
  .
  "code": int,
  "message": string,
};
```
but I cannot tell if that is or ever was correct.

Should the documentation also mention that `RCTCameraRoll` has to be linked and appropriate permissions be set?