### PR TITLE
Fix #402 TextInput.dataDetectorTypes

### DIFF
--- a/bs-react-native-next/src/components/TextInput.bs.js
+++ b/bs-react-native-next/src/components/TextInput.bs.js
@@ -1,1 +1,7 @@
-/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */
+'use strict';
+
+
+var DataDetectorTypes = 0;
+
+exports.DataDetectorTypes = DataDetectorTypes;
+/* No side effect */

--- a/bs-react-native-next/src/components/TextInput.md
+++ b/bs-react-native-next/src/components/TextInput.md
@@ -50,6 +50,8 @@ type selectionEvent = event(selection);
 
 type keyPressEvent = event({. "key": string});
 
+module DataDetectorTypes = TextInput_DataDetectorTypes;
+
 [@react.component] [@bs.module "react-native"]
 external make:
   (
@@ -92,17 +94,7 @@ external make:
                         =?,
     ~clearTextOnFocus: bool=?,
     ~contextMenuHidden: bool=?,
-    ~dataDetectorTypes: array(
-                          [
-                            | `phoneNumber
-                            | `link
-                            | `address
-                            | `calendarEvent
-                            | `none
-                            | `all
-                          ],
-                        )
-                          =?,
+    ~dataDetectorTypes: array(DataDetectorTypes.t)=?,
     ~defaultValue: string=?,
     ~disableFullscreenUI: bool=?,
     ~editable: bool=?,

--- a/bs-react-native-next/src/components/TextInput.re
+++ b/bs-react-native-next/src/components/TextInput.re
@@ -43,6 +43,8 @@ type selectionEvent = event(selection);
 
 type keyPressEvent = event({. "key": string});
 
+module DataDetectorTypes = TextInput_DataDetectorTypes;
+
 [@react.component] [@bs.module "react-native"]
 external make:
   (
@@ -85,17 +87,7 @@ external make:
                         =?,
     ~clearTextOnFocus: bool=?,
     ~contextMenuHidden: bool=?,
-    ~dataDetectorTypes: array(
-                          [
-                            | `phoneNumber
-                            | `link
-                            | `address
-                            | `calendarEvent
-                            | `none
-                            | `all
-                          ],
-                        )
-                          =?,
+    ~dataDetectorTypes: array(DataDetectorTypes.t)=?,
     ~defaultValue: string=?,
     ~disableFullscreenUI: bool=?,
     ~editable: bool=?,

--- a/bs-react-native-next/src/types/TextInput_DataDetectorTypes.bs.js
+++ b/bs-react-native-next/src/types/TextInput_DataDetectorTypes.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/bs-react-native-next/src/types/TextInput_DataDetectorTypes.re
+++ b/bs-react-native-next/src/types/TextInput_DataDetectorTypes.re
@@ -1,0 +1,19 @@
+type t = string;
+
+[@bs.inline]
+let phoneNumber = "phoneNumber";
+
+[@bs.inline]
+let link = "link";
+
+[@bs.inline]
+let address = "address";
+
+[@bs.inline]
+let calendarEvent = "calendarEvent";
+
+[@bs.inline]
+let none = "none";
+
+[@bs.inline]
+let all = "all";

--- a/bs-react-native-next/src/types/TextInput_DataDetectorTypes.rei
+++ b/bs-react-native-next/src/types/TextInput_DataDetectorTypes.rei
@@ -1,0 +1,19 @@
+type t;
+
+[@bs.inline "phoneNumber"]
+let phoneNumber: t;
+
+[@bs.inline "link"]
+let link: t;
+
+[@bs.inline "address"]
+let address: t;
+
+[@bs.inline "calendarEvent"]
+let calendarEvent: t;
+
+[@bs.inline "none"]
+let none: t;
+
+[@bs.inline "all"]
+let all: t;


### PR DESCRIPTION
As requested in #402 we now use dataDetectorTypes in TextInput in the same vein as we already do with WebView.

Closes #402 