### PR TITLE
Complete implementation of CoreEventTypes

### DIFF
--- a/bs-react-native-next/src/apis/Event.md
+++ b/bs-react-native-next/src/apis/Event.md
@@ -29,6 +29,7 @@ type syntheticEvent('a) = {
 
 type responderSyntheticEvent('a) = {
   .
+  // synthethicEvent keys
   "bubbles": Js.Nullable.t(bool),
   "cancelable": Js.Nullable.t(bool),
   "currentTarget": float,
@@ -45,6 +46,7 @@ type responderSyntheticEvent('a) = {
   "target": Js.Nullable.t(float),
   "timeStamp": float,
   "_type": Js.Nullable.t(string),
+  // responderSyntheticEvent specific key
   "touchHistory": {
     .
     "indexOfSingleActiveTouch": float,

--- a/bs-react-native-next/src/apis/Event.md
+++ b/bs-react-native-next/src/apis/Event.md
@@ -7,7 +7,92 @@ wip: true
 ```reason
 // see https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js
 
-type event('a) = {. "nativeEvent": 'a};
+type syntheticEvent('a) = {
+  .
+  "bubbles": Js.Nullable.t(bool),
+  "cancelable": Js.Nullable.t(bool),
+  "currentTarget": float,
+  "defaultPrevented": Js.Nullable.t(bool),
+  "dispatchConfig": {. "registrationName": string},
+  "eventPhase": Js.Nullable.t(float),
+  "preventDefault": unit => unit,
+  "isDefaultPrevented": unit => bool,
+  "stopPropagation": unit => unit,
+  "isPropagationStopped": unit => bool,
+  "isTrusted": Js.Nullable.t(bool),
+  "nativeEvent": 'a,
+  "persist": unit => unit,
+  "target": Js.Nullable.t(float),
+  "timeStamp": float,
+  "_type": Js.Nullable.t(string),
+};
+
+type responderSyntheticEvent('a) = {
+  .
+  "bubbles": Js.Nullable.t(bool),
+  "cancelable": Js.Nullable.t(bool),
+  "currentTarget": float,
+  "defaultPrevented": Js.Nullable.t(bool),
+  "dispatchConfig": {. "registrationName": string},
+  "eventPhase": Js.Nullable.t(float),
+  "preventDefault": unit => unit,
+  "isDefaultPrevented": unit => bool,
+  "stopPropagation": unit => unit,
+  "isPropagationStopped": unit => bool,
+  "isTrusted": Js.Nullable.t(bool),
+  "nativeEvent": 'a,
+  "persist": unit => unit,
+  "target": Js.Nullable.t(float),
+  "timeStamp": float,
+  "_type": Js.Nullable.t(string),
+  "touchHistory": {
+    .
+    "indexOfSingleActiveTouch": float,
+    "mostRecentTimeStamp": float,
+    "numberActiveTouches": float,
+    "touchBank":
+      array({
+        .
+        "touchActive": bool,
+        "startPageX": float,
+        "startPageY": float,
+        "startTimeStamp": float,
+        "currentPageX": float,
+        "currentPageY": float,
+        "currentTimeStamp": float,
+        "previousPageX": float,
+        "previousPageY": float,
+        "previousTimeStamp": float,
+      }),
+  },
+};
+
+type textLayout = {
+  .
+  "x": float,
+  "y": float,
+  "width": float,
+  "height": float,
+  "ascender": float, // verify
+  "capHeight": float, // verify
+  "descender": float, // verify
+  "text": string,
+  "xHeight": float // verify
+};
+
+type layoutEvent =
+  syntheticEvent({
+    .
+    "layout": {
+      .
+      "x": float,
+      "y": float,
+      "width": float,
+      "height": float,
+    },
+  });
+
+type textLayoutEvent = syntheticEvent({. "lines": array(textLayout)});
 
 type pressEventPayload = {
   .
@@ -23,7 +108,7 @@ type pressEventPayload = {
   "touches": array(pressEventPayload),
 };
 
-type pressEvent = event(pressEventPayload);
+type pressEvent = responderSyntheticEvent(pressEventPayload);
 
 type position = {
   .
@@ -38,7 +123,7 @@ type dimensions = {
 };
 
 type scrollEvent =
-  event({
+  syntheticEvent({
     .
     "contentInset": {
       .
@@ -52,16 +137,6 @@ type scrollEvent =
     "layoutMeasurement": dimensions,
   });
 
-type layoutEvent =
-  event({
-    .
-    "layout": {
-      .
-      "x": float,
-      "y": float,
-      "width": float,
-      "height": float,
-    },
-  });
+type switchChangeEvent = syntheticEvent({. "value": bool});
     
 ```

--- a/bs-react-native-next/src/apis/Event.md
+++ b/bs-react-native-next/src/apis/Event.md
@@ -46,7 +46,7 @@ type responderSyntheticEvent('a) = {
   "target": Js.Nullable.t(float),
   "timeStamp": float,
   "_type": Js.Nullable.t(string),
-  // responderSyntheticEvent specific key
+  // responderSyntheticEvent additional key
   "touchHistory": {
     .
     "indexOfSingleActiveTouch": float,

--- a/bs-react-native-next/src/apis/Event.re
+++ b/bs-react-native-next/src/apis/Event.re
@@ -39,7 +39,7 @@ type responderSyntheticEvent('a) = {
   "target": Js.Nullable.t(float),
   "timeStamp": float,
   "_type": Js.Nullable.t(string),
-  // responderSyntheticEvent specific key
+  // responderSyntheticEvent additional key
   "touchHistory": {
     .
     "indexOfSingleActiveTouch": float,

--- a/bs-react-native-next/src/apis/Event.re
+++ b/bs-react-native-next/src/apis/Event.re
@@ -22,6 +22,7 @@ type syntheticEvent('a) = {
 
 type responderSyntheticEvent('a) = {
   .
+  // synthethicEvent keys
   "bubbles": Js.Nullable.t(bool),
   "cancelable": Js.Nullable.t(bool),
   "currentTarget": float,
@@ -38,6 +39,7 @@ type responderSyntheticEvent('a) = {
   "target": Js.Nullable.t(float),
   "timeStamp": float,
   "_type": Js.Nullable.t(string),
+  // responderSyntheticEvent specific key
   "touchHistory": {
     .
     "indexOfSingleActiveTouch": float,

--- a/bs-react-native-next/src/apis/Event.re
+++ b/bs-react-native-next/src/apis/Event.re
@@ -1,6 +1,91 @@
 // see https://github.com/facebook/react-native/blob/master/Libraries/Types/CoreEventTypes.js
 
-type event('a) = {. "nativeEvent": 'a};
+type syntheticEvent('a) = {
+  .
+  "bubbles": Js.Nullable.t(bool),
+  "cancelable": Js.Nullable.t(bool),
+  "currentTarget": float,
+  "defaultPrevented": Js.Nullable.t(bool),
+  "dispatchConfig": {. "registrationName": string},
+  "eventPhase": Js.Nullable.t(float),
+  "preventDefault": unit => unit,
+  "isDefaultPrevented": unit => bool,
+  "stopPropagation": unit => unit,
+  "isPropagationStopped": unit => bool,
+  "isTrusted": Js.Nullable.t(bool),
+  "nativeEvent": 'a,
+  "persist": unit => unit,
+  "target": Js.Nullable.t(float),
+  "timeStamp": float,
+  "_type": Js.Nullable.t(string),
+};
+
+type responderSyntheticEvent('a) = {
+  .
+  "bubbles": Js.Nullable.t(bool),
+  "cancelable": Js.Nullable.t(bool),
+  "currentTarget": float,
+  "defaultPrevented": Js.Nullable.t(bool),
+  "dispatchConfig": {. "registrationName": string},
+  "eventPhase": Js.Nullable.t(float),
+  "preventDefault": unit => unit,
+  "isDefaultPrevented": unit => bool,
+  "stopPropagation": unit => unit,
+  "isPropagationStopped": unit => bool,
+  "isTrusted": Js.Nullable.t(bool),
+  "nativeEvent": 'a,
+  "persist": unit => unit,
+  "target": Js.Nullable.t(float),
+  "timeStamp": float,
+  "_type": Js.Nullable.t(string),
+  "touchHistory": {
+    .
+    "indexOfSingleActiveTouch": float,
+    "mostRecentTimeStamp": float,
+    "numberActiveTouches": float,
+    "touchBank":
+      array({
+        .
+        "touchActive": bool,
+        "startPageX": float,
+        "startPageY": float,
+        "startTimeStamp": float,
+        "currentPageX": float,
+        "currentPageY": float,
+        "currentTimeStamp": float,
+        "previousPageX": float,
+        "previousPageY": float,
+        "previousTimeStamp": float,
+      }),
+  },
+};
+
+type textLayout = {
+  .
+  "x": float,
+  "y": float,
+  "width": float,
+  "height": float,
+  "ascender": float, // verify
+  "capHeight": float, // verify
+  "descender": float, // verify
+  "text": string,
+  "xHeight": float // verify
+};
+
+type layoutEvent =
+  syntheticEvent({
+    .
+    "layout": {
+      .
+      "x": float,
+      "y": float,
+      "width": float,
+      "height": float,
+    },
+  });
+
+type textLayoutEvent = syntheticEvent({. "lines": array(textLayout)});
 
 type pressEventPayload = {
   .
@@ -16,7 +101,7 @@ type pressEventPayload = {
   "touches": array(pressEventPayload),
 };
 
-type pressEvent = event(pressEventPayload);
+type pressEvent = responderSyntheticEvent(pressEventPayload);
 
 type position = {
   .
@@ -31,7 +116,7 @@ type dimensions = {
 };
 
 type scrollEvent =
-  event({
+  syntheticEvent({
     .
     "contentInset": {
       .
@@ -45,14 +130,4 @@ type scrollEvent =
     "layoutMeasurement": dimensions,
   });
 
-type layoutEvent =
-  event({
-    .
-    "layout": {
-      .
-      "x": float,
-      "y": float,
-      "width": float,
-      "height": float,
-    },
-  });
+type switchChangeEvent = syntheticEvent({. "value": bool});

--- a/bs-react-native-next/src/components/WebView.md
+++ b/bs-react-native-next/src/components/WebView.md
@@ -30,10 +30,10 @@ module Source = {
 module DataDetectorTypes = WebView_DataDetectorTypes;
 module DecelerationRate = WebView_DecelerationRate;
 
-type messageEvent = Event.event({. "data": string});
+type messageEvent = Event.syntheticEvent({. "data": string});
 
 type webViewEvent =
-  Event.event({
+  Event.syntheticEvent({
     .
     "url": string,
     "title": string,

--- a/bs-react-native-next/src/components/WebView.re
+++ b/bs-react-native-next/src/components/WebView.re
@@ -23,10 +23,10 @@ module Source = {
 module DataDetectorTypes = WebView_DataDetectorTypes;
 module DecelerationRate = WebView_DecelerationRate;
 
-type messageEvent = Event.event({. "data": string});
+type messageEvent = Event.syntheticEvent({. "data": string});
 
 type webViewEvent =
-  Event.event({
+  Event.syntheticEvent({
     .
     "url": string,
     "title": string,


### PR DESCRIPTION
Documentation does not list if any keys with types marked with ? can become `null` or not, so I chose to define all such keys to be of type `Js.Nullable.t('a)`.

Likewise, I chose to define all keys of type `number` as `float` until we can determine if they are in fact integers.

Finally, `responderSyntheticEvent` is exactly `syntheticEvent` with the additional key `touchHistory`. It might help to add a comment indicating such, so that if `syntheticEvent` is updated, any future commits mirror any such changes in `responderSyntheticEvent`.