### PR TITLE
reason-react-native: add Animated components

### DIFF
--- a/reason-react-native/src/components/AnimatedImage.bs.js
+++ b/reason-react-native/src/components/AnimatedImage.bs.js
@@ -1,0 +1,11 @@
+'use strict';
+
+var Image$ReactNative = require("../Image.bs.js");
+
+var Source = Image$ReactNative.Source;
+
+var DefaultSource = Image$ReactNative.DefaultSource;
+
+exports.Source = Source;
+exports.DefaultSource = DefaultSource;
+/* No side effect */

--- a/reason-react-native/src/components/AnimatedImage.bs.js
+++ b/reason-react-native/src/components/AnimatedImage.bs.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var Image$ReactNative = require("../Image.bs.js");
+var Image$ReactNative = require("./Image.bs.js");
 
 var Source = Image$ReactNative.Source;
 

--- a/reason-react-native/src/components/AnimatedImage.re
+++ b/reason-react-native/src/components/AnimatedImage.re
@@ -1,0 +1,31 @@
+include Image;
+
+[@react.component] [@bs.module "react-native"] [@bs.scope "Animated"]
+external make:
+  (
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onLoad: unit => unit=?,
+    ~onLoadEnd: unit => unit=?,
+    ~onLoadStart: unit => unit=?,
+    ~resizeMode: [@bs.string] [
+                   | `center
+                   | `contain
+                   | `cover
+                   | `repeat
+                   | `stretch
+                 ]
+                   =?,
+    ~source: Source.t,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~resizeMethod: [@bs.string] [ | `auto | `resize | `scale]=?,
+    ~accessibilityLabel: string=?,
+    ~accessible: bool=?,
+    ~blurRadius: float=?,
+    ~capInsets: Types.insets=?,
+    ~defaultSource: DefaultSource.t=?,
+    ~onPartialLoad: unit => unit=?,
+    ~onProgress: progress => unit=?
+  ) =>
+  React.element =
+  "Image";

--- a/reason-react-native/src/components/AnimatedScrollView.bs.js
+++ b/reason-react-native/src/components/AnimatedScrollView.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/components/AnimatedScrollView.re
+++ b/reason-react-native/src/components/AnimatedScrollView.re
@@ -1,0 +1,131 @@
+include ScrollView;
+
+[@react.component] [@bs.module "react-native"] [@bs.scope "Animated"]
+external make:
+  (
+    ~ref: ref=?,
+    // ScrollView props
+    ~alwaysBounceHorizontal: bool=?,
+    ~alwaysBounceVertical: bool=?,
+    ~automaticallyAdjustContentInsets: bool=?,
+    ~bounces: bool=?,
+    ~bouncesZoom: bool=?,
+    ~canCancelContentTouches: bool=?,
+    ~centerContent: bool=?,
+    ~contentContainerStyle: Style.t=?,
+    ~contentInset: Types.insets=?,
+    ~contentInsetAdjustmentBehavior: [@bs.string] [
+                                       | `automatic
+                                       | `scrollableAxes
+                                       | `never
+                                       | `always
+                                     ]
+                                       =?,
+    ~contentOffset: Types.point=?,
+    ~decelerationRate: [@bs.string] [ | `fast | `normal]=?,
+    ~directionalLockEnabled: bool=?,
+    ~endFillColor: Style.color=?,
+    ~horizontal: bool=?,
+    ~indicatorStyle: [@bs.string] [ | `default | `black | `white]=?,
+    ~keyboardDismissMode: [@bs.string] [ | `none | `interactive | `onDrag]=?,
+    ~keyboardShouldPersistTaps: [@bs.string] [ | `always | `never | `handled]=?,
+    ~maximumZoomScale: float=?,
+    ~minimumZoomScale: float=?,
+    ~nestedScrollEnabled: bool=?,
+    ~onContentSizeChange: ((float, float)) => unit=?,
+    ~onMomentumScrollBegin: Event.scrollEvent => unit=?,
+    ~onMomentumScrollEnd: Event.scrollEvent => unit=?,
+    ~onScroll: Event.scrollEvent => unit=?,
+    ~onScrollBeginDrag: Event.scrollEvent => unit=?,
+    ~onScrollEndDrag: Event.scrollEvent => unit=?,
+    ~overScrollMode: [@bs.string] [ | `always | `never | `auto]=?,
+    ~pagingEnabled: bool=?,
+    ~refreshControl: React.element=?,
+    ~scrollEnabled: bool=?,
+    ~scrollEventThrottle: int=?,
+    ~scrollIndicatorInsets: Types.insets=?,
+    ~scrollPerfTag: string=?,
+    ~scrollsToTop: bool=?,
+    ~scrollToOverflowEnabled: bool=?,
+    ~showsHorizontalScrollIndicator: bool=?,
+    ~showsVerticalScrollIndicator: bool=?,
+    ~snapToAlignment: [@bs.string] [ | `start | `center | `end_]=?,
+    ~snapToEnd: bool=?,
+    ~snapToInterval: float=?,
+    ~snapToOffsets: array(float)=?,
+    ~snapToStart: bool=?,
+    ~stickyHeaderIndices: list(int)=?,
+    ~zoomScale: float=?,
+    // View props
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.insets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "ScrollView";

--- a/reason-react-native/src/components/AnimatedText.bs.js
+++ b/reason-react-native/src/components/AnimatedText.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/components/AnimatedText.re
+++ b/reason-react-native/src/components/AnimatedText.re
@@ -1,0 +1,26 @@
+[@react.component] [@bs.module "react-native"] [@bs.scope "Animated"]
+external make:
+  (
+    ~accessible: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityLabel: string=?,
+    ~allowFontScaling: bool=?,
+    ~ellipsizeMode: [@bs.string] [ | `clip | `head | `middle | `tail]=?,
+    ~numberOfLines: int=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onLongPress: unit => unit=?,
+    ~onPress: unit => unit=?,
+    ~pressRetentionOffset: Types.insets=?,
+    ~selectable: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~selectionColor: string=?,
+    ~textBreakStrategy: [@bs.string] [ | `simple | `highQuality | `balanced]=?,
+    ~adjustsFontSizeToFit: bool=?,
+    ~minimumFontScale: float=?,
+    ~suppressHighlighting: bool=?,
+    ~value: string=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "Text";

--- a/reason-react-native/src/components/AnimatedView.bs.js
+++ b/reason-react-native/src/components/AnimatedView.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/components/AnimatedView.re
+++ b/reason-react-native/src/components/AnimatedView.re
@@ -1,0 +1,75 @@
+[@react.component] [@bs.module "react-native"] [@bs.scope "Animated"]
+external make:
+  (
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.insets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "View";


### PR DESCRIPTION
We cannot add them into as Animated.* otherwise we run into a cycle dep error (style->animated->style)

This PR is just a copy/paste of exisiting compo with `[@bs.scope "Animated"]`.

I used include for Image & ScrollView method, not sure if we should do it or not.