### PR TITLE
Animated Components (Image, ScrollView, Text, View)

### DIFF
--- a/reason-react-native/src/apis/Animated.bs.js
+++ b/reason-react-native/src/apis/Animated.bs.js
@@ -2,6 +2,7 @@
 
 var Caml_option = require("bs-platform/lib/js/caml_option.js");
 var ReactNative = require("react-native");
+var Image$ReactNative = require("../components/Image.bs.js");
 
 var Animation = /* module */[];
 
@@ -76,6 +77,26 @@ function reset(prim) {
   return /* () */0;
 }
 
+var make = ReactNative.Animated.createAnimatedComponent(ReactNative.Image);
+
+var $$Image = /* module */[
+  /* Source */Image$ReactNative.Source,
+  /* DefaultSource */Image$ReactNative.DefaultSource,
+  /* make */make
+];
+
+var make$1 = ReactNative.Animated.createAnimatedComponent(ReactNative.ScrollView);
+
+var ScrollView = /* module */[/* make */make$1];
+
+var make$2 = ReactNative.Animated.createAnimatedComponent(ReactNative.Text);
+
+var $$Text = /* module */[/* make */make$2];
+
+var make$3 = ReactNative.Animated.createAnimatedComponent(ReactNative.View);
+
+var View = /* module */[/* make */make$3];
+
 exports.Animation = Animation;
 exports.ValueAnimations = ValueAnimations;
 exports.Interpolation = Interpolation;
@@ -88,4 +109,8 @@ exports.decay = decay;
 exports.start = start;
 exports.stop = stop;
 exports.reset = reset;
-/* react-native Not a pure module */
+exports.$$Image = $$Image;
+exports.ScrollView = ScrollView;
+exports.$$Text = $$Text;
+exports.View = View;
+/* make Not a pure module */

--- a/reason-react-native/src/apis/Animated.md
+++ b/reason-react-native/src/apis/Animated.md
@@ -275,4 +275,32 @@ let stop = Animation.stop;
 
 let reset = Animation.reset;
 
+// Unsafe, unfortunately, but allows us to pass animated values everywhere.
+// May be refined later.
+external animatedStyle: value('a) => 'b = "%identity";
+
+module Image = {
+  include Image;
+
+  let make = createAnimatedComponent(make);
+};
+
+module ScrollView = {
+  include ScrollView;
+
+  let make = createAnimatedComponent(make);
+};
+
+module Text = {
+  include Text;
+
+  let make = createAnimatedComponent(make);
+};
+
+module View = {
+  include View;
+
+  let make = createAnimatedComponent(View.make);
+};
+
 ```

--- a/reason-react-native/src/apis/Animated.re
+++ b/reason-react-native/src/apis/Animated.re
@@ -267,3 +267,31 @@ let start = Animation.start;
 let stop = Animation.stop;
 
 let reset = Animation.reset;
+
+// Unsafe, unfortunately, but allows us to pass animated values everywhere.
+// May be refined later.
+external animatedStyle: value('a) => 'b = "%identity";
+
+module Image = {
+  include Image;
+
+  let make = createAnimatedComponent(make);
+};
+
+module ScrollView = {
+  include ScrollView;
+
+  let make = createAnimatedComponent(make);
+};
+
+module Text = {
+  include Text;
+
+  let make = createAnimatedComponent(make);
+};
+
+module View = {
+  include View;
+
+  let make = createAnimatedComponent(View.make);
+};

--- a/reason-react-native/src/apis/Style.md
+++ b/reason-react-native/src/apis/Style.md
@@ -7,10 +7,6 @@ wip: true
 ```reason
 let pct = num => num->Js.Float.toString ++ "%";
 
-// Unsafe, unfortunately, but allows us to pass animated values everywhere.
-// May be refined later.
-external animated: Animated.value('a) => 'b = "%identity";
-
 module Margin = {
   type t;
 

--- a/reason-react-native/src/apis/Style.re
+++ b/reason-react-native/src/apis/Style.re
@@ -1,9 +1,5 @@
 let pct = num => num->Js.Float.toString ++ "%";
 
-// Unsafe, unfortunately, but allows us to pass animated values everywhere.
-// May be refined later.
-external animated: Animated.value('a) => 'b = "%identity";
-
 module Margin = {
   type t;
 


### PR DESCRIPTION
As far as I know, these components are simply the regular component of the same name, wrapped in `Animated.createAnimatedComponent`.

If that is indeed the case, I propose we reimplement the components and not simply create bindings.

PR that @MoOx contributed has the advantage that it would be fine even if RN implementation changes and this would need to be revisited.