### PR TITLE
Zero-cost bindings to ProgressViewIOS

### DIFF
--- a/reason-react-native/src/components/ProgressViewIOS.bs.js
+++ b/reason-react-native/src/components/ProgressViewIOS.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/components/ProgressViewIOS.md
+++ b/reason-react-native/src/components/ProgressViewIOS.md
@@ -1,0 +1,95 @@
+---
+id: components/ProgressViewIOS
+title: ProgressViewIOS
+wip: true
+---
+
+```reason
+type element;
+type ref = React.Ref.t(Js.nullable(element));
+
+[@react.component] [@bs.module "react-native"]
+external make:
+  (
+    ~ref: ref=?,
+    ~progress: float,
+    ~progressImage: Image.Source.t=?,
+    ~progressTintColor: Style.color=?,
+    ~progressViewStyle: [@bs.string] [ | `default | `bar]=?,
+    ~trackImage: Image.Source.t=?,
+    ~trackTintColor: Style.color=?,
+    // View props
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.insets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "ProgressViewIOS";
+
+```

--- a/reason-react-native/src/components/ProgressViewIOS.re
+++ b/reason-react-native/src/components/ProgressViewIOS.re
@@ -1,0 +1,86 @@
+type element;
+type ref = React.Ref.t(Js.nullable(element));
+
+[@react.component] [@bs.module "react-native"]
+external make:
+  (
+    ~ref: ref=?,
+    ~progress: float,
+    ~progressImage: Image.Source.t=?,
+    ~progressTintColor: Style.color=?,
+    ~progressViewStyle: [@bs.string] [ | `default | `bar]=?,
+    ~trackImage: Image.Source.t=?,
+    ~trackTintColor: Style.color=?,
+    // View props
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.insets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?,
+    ~children: React.element=?
+  ) =>
+  React.element =
+  "ProgressViewIOS";


### PR DESCRIPTION
I verified that children are supported so I kept the `children` prop.