### PR TITLE
Zero-cost bindings to DatePickerIOS

### DIFF
--- a/reason-react-native/src/components/DatePickerIOS.bs.js
+++ b/reason-react-native/src/components/DatePickerIOS.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/components/DatePickerIOS.md
+++ b/reason-react-native/src/components/DatePickerIOS.md
@@ -1,0 +1,110 @@
+---
+id: components/DatePickerIOS
+title: DatePickerIOS
+wip: true
+---
+
+```reason
+// For localeId refer to
+// https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
+
+type localeId = string;
+
+[@react.component] [@bs.module "react-native"]
+external make:
+  (
+    ~date: Js.Date.t,
+    ~onDateChange: Js.Date.t => unit,
+    ~maximumDate: Js.Date.t=?,
+    ~minimumDate: Js.Date.t=?,
+    ~minuteInterval: [@bs.string] [
+                       | [@bs.as "1"] `_1
+                       | [@bs.as "2"] `_2
+                       | [@bs.as "3"] `_3
+                       | [@bs.as "4"] `_4
+                       | [@bs.as "5"] `_5
+                       | [@bs.as "6"] `_6
+                       | [@bs.as "10"] `_10
+                       | [@bs.as "12"] `_12
+                       | [@bs.as "15"] `_15
+                       | [@bs.as "20"] `_20
+                       | [@bs.as "30"] `_30
+                     ]
+                       =?,
+    ~mode: [@bs.string] [ | `date | `time | `datetime]=?,
+    ~locale: localeId=?,
+    ~timeZoneOffsetInMinutes: int=?,
+    // View props
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.edgeInsets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?
+  ) =>
+  React.element =
+  "DatePickerIOS";
+
+```

--- a/reason-react-native/src/components/DatePickerIOS.re
+++ b/reason-react-native/src/components/DatePickerIOS.re
@@ -1,0 +1,101 @@
+// For localeId refer to
+// https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html
+
+type localeId = string;
+
+[@react.component] [@bs.module "react-native"]
+external make:
+  (
+    ~date: Js.Date.t,
+    ~onDateChange: Js.Date.t => unit,
+    ~maximumDate: Js.Date.t=?,
+    ~minimumDate: Js.Date.t=?,
+    ~minuteInterval: [@bs.string] [
+                       | [@bs.as "1"] `_1
+                       | [@bs.as "2"] `_2
+                       | [@bs.as "3"] `_3
+                       | [@bs.as "4"] `_4
+                       | [@bs.as "5"] `_5
+                       | [@bs.as "6"] `_6
+                       | [@bs.as "10"] `_10
+                       | [@bs.as "12"] `_12
+                       | [@bs.as "15"] `_15
+                       | [@bs.as "20"] `_20
+                       | [@bs.as "30"] `_30
+                     ]
+                       =?,
+    ~mode: [@bs.string] [ | `date | `time | `datetime]=?,
+    ~locale: localeId=?,
+    ~timeZoneOffsetInMinutes: int=?,
+    // View props
+    ~accessibilityComponentType: [@bs.string] [
+                                   | `none
+                                   | `button
+                                   | `radiobutton_checked
+                                   | `radiobutton_unchecked
+                                 ]
+                                   =?,
+    ~accessibilityElementsHidden: bool=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityLiveRegion: [@bs.string] [ | `none | `polite | `assertive]=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
+    ~accessibilityViewIsModal: bool=?,
+    ~accessible: bool=?,
+    ~collapsable: bool=?,
+    ~hitSlop: Types.edgeInsets=?,
+    ~importantForAccessibility: [@bs.string] [
+                                  | `auto
+                                  | `yes
+                                  | `no
+                                  | [@bs.as "no-hide-descendants"]
+                                    `noHideDescendants
+                                ]
+                                  =?,
+    ~nativeID: string=?,
+    ~needsOffscreenAlphaCompositing: bool=?,
+    ~onAccessibilityTap: unit => unit=?,
+    ~onLayout: Event.layoutEvent => unit=?,
+    ~onMagicTap: unit => unit=?,
+    // Gesture Responder props
+    ~onMoveShouldSetResponder: Event.pressEvent => bool=?,
+    ~onMoveShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~onResponderGrant: Event.pressEvent => unit=?,
+    ~onResponderMove: Event.pressEvent => unit=?,
+    ~onResponderReject: Event.pressEvent => unit=?,
+    ~onResponderRelease: Event.pressEvent => unit=?,
+    ~onResponderTerminate: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onStartShouldSetResponder: Event.pressEvent => bool=?,
+    ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
+    ~pointerEvents: [@bs.string] [
+                      | `auto
+                      | `none
+                      | [@bs.as "box-none"] `boxNone
+                      | [@bs.as "box-only"] `boxOnly
+                    ]
+                      =?,
+    ~removeClippedSubviews: bool=?,
+    ~renderToHardwareTextureAndroid: bool=?,
+    ~shouldRasterizeIOS: bool=?,
+    ~style: Style.t=?,
+    ~testID: string=?
+  ) =>
+  React.element =
+  "DatePickerIOS";


### PR DESCRIPTION
Does not support `ref` or `children`.