### PR TITLE
reason-react-native: fixes & improvements on Touchables

### DIFF
--- a/reason-react-native/src/components/TouchableHighlight.md
+++ b/reason-react-native/src/components/TouchableHighlight.md
@@ -13,8 +13,15 @@ external make:
   (
     ~ref: ref=?,
     // TouchableHighlight props
+    ~activeOpacity: float=?,
+    ~hasTVPreferredFocus: bool=?,
+    ~onHideUnderlay: unit => unit=?,
+    ~onShowUnderlay: unit => unit=?,
+    ~style: Style.t=?,
+    ~tvParallaxProperties: TV.parallax=?,
+    ~underlayColor: string=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -22,6 +29,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -37,6 +47,7 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -48,13 +59,6 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~activeOpacity: float=?,
-    ~onHideUnderlay: unit => unit=?,
-    ~onShowUnderlay: unit => unit=?,
-    ~style: Style.t=?,
-    ~underlayColor: string=?,
-    ~hasTVPreferredFocus: bool=?,
-    ~tvParallaxProperties: Js.t({.})=?,
     ~testID: string=?,
     ~children: React.element=?
   ) =>

--- a/reason-react-native/src/components/TouchableHighlight.re
+++ b/reason-react-native/src/components/TouchableHighlight.re
@@ -6,8 +6,15 @@ external make:
   (
     ~ref: ref=?,
     // TouchableHighlight props
+    ~activeOpacity: float=?,
+    ~hasTVPreferredFocus: bool=?,
+    ~onHideUnderlay: unit => unit=?,
+    ~onShowUnderlay: unit => unit=?,
+    ~style: Style.t=?,
+    ~tvParallaxProperties: TV.parallax=?,
+    ~underlayColor: string=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -15,6 +22,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -30,6 +40,7 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -41,13 +52,6 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~activeOpacity: float=?,
-    ~onHideUnderlay: unit => unit=?,
-    ~onShowUnderlay: unit => unit=?,
-    ~style: Style.t=?,
-    ~underlayColor: string=?,
-    ~hasTVPreferredFocus: bool=?,
-    ~tvParallaxProperties: Js.t({.})=?,
     ~testID: string=?,
     ~children: React.element=?
   ) =>

--- a/reason-react-native/src/components/TouchableNativeFeedback.md
+++ b/reason-react-native/src/components/TouchableNativeFeedback.md
@@ -30,8 +30,10 @@ external make:
   (
     ~ref: ref=?,
     // TouchableNativeFeedback props
+    ~background: Background.t=?,
+    ~useForeground: bool=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -39,7 +41,25 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
-    ~accessibilityTraits: array(string)=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -51,11 +71,8 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~style: Style.t=?,
-    ~background: Background.t=?,
-    ~useForeground: bool=?,
     ~testID: string=?,
-    ~children: React.element
+    ~children: React.element=?
   ) =>
   React.element =
   "TouchableNativeFeedback";

--- a/reason-react-native/src/components/TouchableNativeFeedback.re
+++ b/reason-react-native/src/components/TouchableNativeFeedback.re
@@ -23,8 +23,10 @@ external make:
   (
     ~ref: ref=?,
     // TouchableNativeFeedback props
+    ~background: Background.t=?,
+    ~useForeground: bool=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -32,7 +34,25 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
-    ~accessibilityTraits: array(string)=?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
+    ~accessibilityRole: [@bs.string] [
+                          | `none
+                          | `button
+                          | `link
+                          | `search
+                          | `image
+                          | `keyboardkey
+                          | `text
+                          | `adjustable
+                          | `header
+                          | `summary
+                          | `imagebutton
+                        ]
+                          =?,
+    ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -44,11 +64,8 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~style: Style.t=?,
-    ~background: Background.t=?,
-    ~useForeground: bool=?,
     ~testID: string=?,
-    ~children: React.element
+    ~children: React.element=?
   ) =>
   React.element =
   "TouchableNativeFeedback";

--- a/reason-react-native/src/components/TouchableOpacity.md
+++ b/reason-react-native/src/components/TouchableOpacity.md
@@ -12,9 +12,13 @@ type ref = React.Ref.t(Js.nullable(element));
 external make:
   (
     ~ref: ref=?,
-    // TouchableOpacity props
+    ~activeOpacity: float=?,
+    ~focusedOpacity: float=?,
+    ~hasTVPreferredFocus: bool=?,
+    ~style: Style.t=?,
+    ~tvParallaxProperties: TV.parallax=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -22,6 +26,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -37,23 +44,19 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
     ~disabled: bool=?,
     ~hitSlop: Types.edgeInsets=?,
-    ~style: Style.t=?,
     ~onLayout: Event.layoutEvent => unit=?,
     ~onLongPress: Event.pressEvent => unit=?,
     ~onPress: Event.pressEvent => unit=?,
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~activeOpacity: float=?,
-    ~focusedOpacity: float=?,
     ~testID: string=?,
-    // FIXME
-    ~tvParallaxProperties: Js.t({.})=?,
     ~children: React.element=?
   ) =>
   React.element =
@@ -62,4 +65,5 @@ external make:
 [@bs.send]
 external setOpacityTo: (ref, ~value: float, ~duration: float) => unit =
   "setOpacityTo";
+
 ```

--- a/reason-react-native/src/components/TouchableOpacity.re
+++ b/reason-react-native/src/components/TouchableOpacity.re
@@ -5,9 +5,13 @@ type ref = React.Ref.t(Js.nullable(element));
 external make:
   (
     ~ref: ref=?,
-    // TouchableOpacity props
+    ~activeOpacity: float=?,
+    ~focusedOpacity: float=?,
+    ~hasTVPreferredFocus: bool=?,
+    ~style: Style.t=?,
+    ~tvParallaxProperties: TV.parallax=?,
+    // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -15,6 +19,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -30,23 +37,19 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
     ~disabled: bool=?,
     ~hitSlop: Types.edgeInsets=?,
-    ~style: Style.t=?,
     ~onLayout: Event.layoutEvent => unit=?,
     ~onLongPress: Event.pressEvent => unit=?,
     ~onPress: Event.pressEvent => unit=?,
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~activeOpacity: float=?,
-    ~focusedOpacity: float=?,
     ~testID: string=?,
-    // FIXME
-    ~tvParallaxProperties: Js.t({.})=?,
     ~children: React.element=?
   ) =>
   React.element =

--- a/reason-react-native/src/components/TouchableWithoutFeedback.md
+++ b/reason-react-native/src/components/TouchableWithoutFeedback.md
@@ -14,7 +14,6 @@ external make:
     ~ref: ref=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -22,6 +21,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -37,6 +39,7 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -48,7 +51,6 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~style: Style.t=?,
     ~testID: string=?,
     ~children: React.element=?
   ) =>

--- a/reason-react-native/src/components/TouchableWithoutFeedback.re
+++ b/reason-react-native/src/components/TouchableWithoutFeedback.re
@@ -7,7 +7,6 @@ external make:
     ~ref: ref=?,
     // TouchableWithoutFeedback props
     ~accessible: bool=?,
-    ~accessibilityLabel: string=?,
     ~accessibilityComponentType: [@bs.string] [
                                    | `none
                                    | `button
@@ -15,6 +14,9 @@ external make:
                                    | `radiobutton_unchecked
                                  ]
                                    =?,
+    ~accessibilityHint: string=?,
+    ~accessibilityIgnoresInvertColors: bool=?,
+    ~accessibilityLabel: string=?,
     ~accessibilityRole: [@bs.string] [
                           | `none
                           | `button
@@ -30,6 +32,7 @@ external make:
                         ]
                           =?,
     ~accessibilityStates: array(AccessibilityState.t)=?,
+    ~accessibilityTraits: array(AccessibilityTrait.t)=?,
     ~delayLongPress: int=?,
     ~delayPressIn: int=?,
     ~delayPressOut: int=?,
@@ -41,7 +44,6 @@ external make:
     ~onPressIn: Event.pressEvent => unit=?,
     ~onPressOut: Event.pressEvent => unit=?,
     ~pressRetentionOffset: Types.edgeInsets=?,
-    ~style: Style.t=?,
     ~testID: string=?,
     ~children: React.element=?
   ) =>

--- a/reason-react-native/src/types/TV.bs.js
+++ b/reason-react-native/src/types/TV.bs.js
@@ -1,0 +1,7 @@
+'use strict';
+
+
+var parallaxDefault = true;
+
+exports.parallaxDefault = parallaxDefault;
+/* No side effect */

--- a/reason-react-native/src/types/TV.re
+++ b/reason-react-native/src/types/TV.re
@@ -1,0 +1,18 @@
+type parallax;
+
+[@bs.obj]
+external parallax:
+  (
+    ~shiftDistanceX: float,
+    ~shiftDistanceY: float,
+    ~tiltAngle: float,
+    ~magnification: float,
+    ~pressMagnification: float,
+    ~pressDuration: float,
+    ~pressDelay: float,
+    unit
+  ) =>
+  parallax =
+  "";
+
+let parallaxDefault: parallax = true->Obj.magic;


### PR DESCRIPTION
- TouchableWithoutFeedback doesn't have `style` (it's cloning its child)
- I reordered props so we can easier track what props are from TouchableWithoutFeedback
- I added `tvParallaxProperties` type & a magic to have defaults (RN accept object or `true` to get default values
- Fixed accessibility props for all touchables
