### PR TITLE
Add unit to Animated.Interpolation

### DIFF
--- a/reason-react-native/src/apis/Animated.md
+++ b/reason-react-native/src/apis/Animated.md
@@ -130,7 +130,8 @@ module Interpolation = {
       ~easing: Easing.t=?,
       ~extrapolate: [@bs.string] [ | `extend | `clamp | `identity]=?,
       ~extrapolateLeft: [@bs.string] [ | `extend | `clamp | `identity]=?,
-      ~extrapolateRight: [@bs.string] [ | `extend | `clamp | `identity]=?
+      ~extrapolateRight: [@bs.string] [ | `extend | `clamp | `identity]=?,
+      unit
     ) =>
     config =
     "";

--- a/reason-react-native/src/apis/Animated.re
+++ b/reason-react-native/src/apis/Animated.re
@@ -123,7 +123,8 @@ module Interpolation = {
       ~easing: Easing.t=?,
       ~extrapolate: [@bs.string] [ | `extend | `clamp | `identity]=?,
       ~extrapolateLeft: [@bs.string] [ | `extend | `clamp | `identity]=?,
-      ~extrapolateRight: [@bs.string] [ | `extend | `clamp | `identity]=?
+      ~extrapolateRight: [@bs.string] [ | `extend | `clamp | `identity]=?,
+      unit
     ) =>
     config =
     "";


### PR DESCRIPTION
Adding `unit` so that arguments to the config function are indeed optional.