### PR TITLE
Zero-cost bindings to CameraRoll API

### DIFF
--- a/reason-react-native/src/apis/CameraRoll.bs.js
+++ b/reason-react-native/src/apis/CameraRoll.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/apis/CameraRoll.md
+++ b/reason-react-native/src/apis/CameraRoll.md
@@ -70,14 +70,15 @@ type photoIdentifiersPage = {
 };
 
 [@bs.module "react-native"] [@bs.scope "CameraRoll"]
-external saveToCameraRoll:
-  (string, ~_type: [@bs.string] [ | `photo | `video]=?, unit) =>
-  Js.Promise.t(string) =
+external saveToCameraRoll: string => Js.Promise.t(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external saveToCameraRollOverrideType:
+  (string, ~_type: [@bs.string] [ | `photo | `video]) => Js.Promise.t(string) =
   "";
 
 [@bs.module "react-native"] [@bs.scope "CameraRoll"]
 external getPhotos: getPhotosParams => Js.Promise.t(photoIdentifiersPage) =
   "";
-
 
 ```

--- a/reason-react-native/src/apis/CameraRoll.md
+++ b/reason-react-native/src/apis/CameraRoll.md
@@ -1,0 +1,83 @@
+---
+id: apis/CameraRoll
+title: CameraRoll
+wip: true
+---
+
+```reason
+type getPhotosParams;
+
+[@bs.obj]
+external getPhotosParams:
+  (
+    ~first: int,
+    ~after: string=?,
+    ~groupTypes: [@bs.string] [
+                   | `Album
+                   | `All
+                   | `Event
+                   | `Faces
+                   | `Library
+                   | `PhotoStream
+                   | `SavedPhotos
+                 ]
+                   =?,
+    ~groupName: string=?,
+    ~assetType: [@bs.string] [ | `All | `Videos | `Photos]=?,
+    ~mimeTypes: array(string)=?,
+    unit
+  ) =>
+  getPhotosParams =
+  "";
+
+type photoIdentifier = {
+  .
+  "node": {
+    .
+    "_type": string,
+    "group_name": string,
+    "image": {
+      .
+      "filename": string,
+      "uri": string,
+      "height": float,
+      "width": float,
+      "isStored": Js.Nullable.t(bool),
+      "playableDuration": float,
+    },
+    "timestamp": float,
+    "location":
+      Js.Nullable.t({
+        .
+        "latitude": Js.Nullable.t(float),
+        "longitude": Js.Nullable.t(float),
+        "altitude": Js.Nullable.t(float),
+        "heading": Js.Nullable.t(float),
+        "speed": Js.Nullable.t(float),
+      }),
+  },
+};
+
+type photoIdentifiersPage = {
+  .
+  "edges": array(photoIdentifier),
+  "page_info": {
+    .
+    "has_next_page": bool,
+    "start_cursor": Js.Nullable.t(string),
+    "end_cursor": Js.Nullable.t(string),
+  },
+};
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external saveToCameraRoll:
+  (string, ~_type: [@bs.string] [ | `photo | `video]=?, unit) =>
+  Js.Promise.t(string) =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external getPhotos: getPhotosParams => Js.Promise.t(photoIdentifiersPage) =
+  "";
+
+
+```

--- a/reason-react-native/src/apis/CameraRoll.re
+++ b/reason-react-native/src/apis/CameraRoll.re
@@ -1,0 +1,73 @@
+type getPhotosParams;
+
+[@bs.obj]
+external getPhotosParams:
+  (
+    ~first: int,
+    ~after: string=?,
+    ~groupTypes: [@bs.string] [
+                   | `Album
+                   | `All
+                   | `Event
+                   | `Faces
+                   | `Library
+                   | `PhotoStream
+                   | `SavedPhotos
+                 ]
+                   =?,
+    ~groupName: string=?,
+    ~assetType: [@bs.string] [ | `All | `Videos | `Photos]=?,
+    ~mimeTypes: array(string)=?,
+    unit
+  ) =>
+  getPhotosParams =
+  "";
+
+type photoIdentifier = {
+  .
+  "node": {
+    .
+    "_type": string,
+    "group_name": string,
+    "image": {
+      .
+      "filename": string,
+      "uri": string,
+      "height": float,
+      "width": float,
+      "isStored": Js.Nullable.t(bool),
+      "playableDuration": float,
+    },
+    "timestamp": float,
+    "location":
+      Js.Nullable.t({
+        .
+        "latitude": Js.Nullable.t(float),
+        "longitude": Js.Nullable.t(float),
+        "altitude": Js.Nullable.t(float),
+        "heading": Js.Nullable.t(float),
+        "speed": Js.Nullable.t(float),
+      }),
+  },
+};
+
+type photoIdentifiersPage = {
+  .
+  "edges": array(photoIdentifier),
+  "page_info": {
+    .
+    "has_next_page": bool,
+    "start_cursor": Js.Nullable.t(string),
+    "end_cursor": Js.Nullable.t(string),
+  },
+};
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external saveToCameraRoll:
+  (string, ~_type: [@bs.string] [ | `photo | `video]=?, unit) =>
+  Js.Promise.t(string) =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external getPhotos: getPhotosParams => Js.Promise.t(photoIdentifiersPage) =
+  "";

--- a/reason-react-native/src/apis/CameraRoll.re
+++ b/reason-react-native/src/apis/CameraRoll.re
@@ -63,9 +63,11 @@ type photoIdentifiersPage = {
 };
 
 [@bs.module "react-native"] [@bs.scope "CameraRoll"]
-external saveToCameraRoll:
-  (string, ~_type: [@bs.string] [ | `photo | `video]=?, unit) =>
-  Js.Promise.t(string) =
+external saveToCameraRoll: string => Js.Promise.t(string) = "";
+
+[@bs.module "react-native"] [@bs.scope "CameraRoll"]
+external saveToCameraRollOverrideType:
+  (string, ~_type: [@bs.string] [ | `photo | `video]) => Js.Promise.t(string) =
   "";
 
 [@bs.module "react-native"] [@bs.scope "CameraRoll"]


### PR DESCRIPTION
Since `?` in flow does not distinguish between `null` and `undefined`, I kept optional keys to be of type `Js.Nullable.t('a)` as before.