### PR TITLE
Move Margin and Size modules out of Style module.

### DIFF
--- a/reason-react-native/src/apis/Style.bs.js
+++ b/reason-react-native/src/apis/Style.bs.js
@@ -1,17 +1,6 @@
 'use strict';
 
 
-function pct(num) {
-  return num.toString() + "%";
-}
-
-var Margin = /* module */[
-  /* pct */pct,
-  /* auto */"auto"
-];
-
-var Size = /* module */[/* pct */pct];
-
 function deg(num) {
   return num.toString() + "deg";
 }
@@ -25,8 +14,5 @@ var Transform = /* module */[
   /* rad */rad
 ];
 
-exports.pct = pct;
-exports.Margin = Margin;
-exports.Size = Size;
 exports.Transform = Transform;
 /* No side effect */

--- a/reason-react-native/src/apis/Style.re
+++ b/reason-react-native/src/apis/Style.re
@@ -1,20 +1,3 @@
-let pct = num => num->Js.Float.toString ++ "%";
-
-module Margin = {
-  type t;
-
-  external pt: float => t = "%identity";
-  let pct: float => t = pct->Obj.magic;
-  let auto: t = "auto"->Obj.magic;
-};
-
-module Size = {
-  type t;
-
-  external pt: float => t = "%identity";
-  let pct: float => t = pct->Obj.magic;
-};
-
 module Transform = {
   type angle;
 

--- a/reason-react-native/src/types/Margin.bs.js
+++ b/reason-react-native/src/types/Margin.bs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+
+function pct(num) {
+  return num.toString() + "%";
+}
+
+exports.pct = pct;
+/* No side effect */

--- a/reason-react-native/src/types/Margin.re
+++ b/reason-react-native/src/types/Margin.re
@@ -1,0 +1,8 @@
+type t = string;
+
+external pt: float => t = "%identity";
+
+let pct = num => num->Js.Float.toString ++ "%";
+
+[@bs.inline]
+let auto = "auto";

--- a/reason-react-native/src/types/Margin.rei
+++ b/reason-react-native/src/types/Margin.rei
@@ -1,0 +1,8 @@
+type t;
+
+external pt: float => t = "%identity";
+
+let pct: float => t;
+
+[@bs.inline "auto"]
+let auto: t;

--- a/reason-react-native/src/types/Size.bs.js
+++ b/reason-react-native/src/types/Size.bs.js
@@ -1,0 +1,9 @@
+'use strict';
+
+
+function pct(num) {
+  return num.toString() + "%";
+}
+
+exports.pct = pct;
+/* No side effect */

--- a/reason-react-native/src/types/Size.re
+++ b/reason-react-native/src/types/Size.re
@@ -1,0 +1,5 @@
+type t = string;
+
+external pt: float => t = "%identity";
+
+let pct = num => num->Js.Float.toString ++ "%";

--- a/reason-react-native/src/types/Size.rei
+++ b/reason-react-native/src/types/Size.rei
@@ -1,0 +1,5 @@
+type t;
+
+external pt: float => t = "%identity";
+
+let pct: float => t;


### PR DESCRIPTION
Advantages:

1. The `auto` constant can be inlined.

2. The user can now do

```re
Style.style(~margin=Margin.pt(4.), ());
```

instead of

```re
Style.(style(~margin=Margin.pt(4.), ()));
```