### PR TITLE
Target event

### DIFF
--- a/reason-react-native/src/apis/Event.md
+++ b/reason-react-native/src/apis/Event.md
@@ -141,4 +141,6 @@ type scrollEvent =
 
 type switchChangeEvent = syntheticEvent({. "value": bool});
 
+type targetEvent = syntheticEvent({. "target": int});
+
 ```

--- a/reason-react-native/src/apis/Event.re
+++ b/reason-react-native/src/apis/Event.re
@@ -133,3 +133,5 @@ type scrollEvent =
   });
 
 type switchChangeEvent = syntheticEvent({. "value": bool});
+
+type targetEvent = syntheticEvent({. "target": int});

--- a/reason-react-native/src/components/TextInput.md
+++ b/reason-react-native/src/components/TextInput.md
@@ -27,8 +27,6 @@ type contentSizeChangeEvent =
     },
   });
 
-type focusEvent = event({. "target": int});
-
 type scrollEvent =
   event({
     .
@@ -136,7 +134,7 @@ external make:
     ~onChangeText: string => unit=?,
     ~onContentSizeChange: contentSizeChangeEvent => unit=?,
     ~onEndEditing: editingEvent => unit=?,
-    ~onFocus: focusEvent => unit=?,
+    ~onFocus: Event.targetEvent => unit=?,
     ~onKeyPress: keyPressEvent => unit=?,
     ~onScroll: scrollEvent => unit=?,
     ~onSelectionChange: selectionEvent => unit=?,

--- a/reason-react-native/src/components/TextInput.re
+++ b/reason-react-native/src/components/TextInput.re
@@ -20,8 +20,6 @@ type contentSizeChangeEvent =
     },
   });
 
-type focusEvent = event({. "target": int});
-
 type scrollEvent =
   event({
     .
@@ -129,7 +127,7 @@ external make:
     ~onChangeText: string => unit=?,
     ~onContentSizeChange: contentSizeChangeEvent => unit=?,
     ~onEndEditing: editingEvent => unit=?,
-    ~onFocus: focusEvent => unit=?,
+    ~onFocus: Event.targetEvent => unit=?,
     ~onKeyPress: keyPressEvent => unit=?,
     ~onScroll: scrollEvent => unit=?,
     ~onSelectionChange: selectionEvent => unit=?,

--- a/reason-react-native/src/components/TouchableWithoutFeedback.md
+++ b/reason-react-native/src/components/TouchableWithoutFeedback.md
@@ -44,6 +44,8 @@ external make:
     ~delayPressOut: int=?,
     ~disabled: bool=?,
     ~hitSlop: Types.edgeInsets=?,
+    ~onBlur: Event.targetEvent => unit=?,
+    ~onFocus: Event.targetEvent => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,
     ~onLongPress: Event.pressEvent => unit=?,
     ~onPress: Event.pressEvent => unit=?,

--- a/reason-react-native/src/components/TouchableWithoutFeedback.re
+++ b/reason-react-native/src/components/TouchableWithoutFeedback.re
@@ -37,6 +37,8 @@ external make:
     ~delayPressOut: int=?,
     ~disabled: bool=?,
     ~hitSlop: Types.edgeInsets=?,
+    ~onBlur: Event.targetEvent => unit=?,
+    ~onFocus: Event.targetEvent => unit=?,
     ~onLayout: Event.layoutEvent => unit=?,
     ~onLongPress: Event.pressEvent => unit=?,
     ~onPress: Event.pressEvent => unit=?,


### PR DESCRIPTION
`focusEvent` (in `TouchableWithoutFeedback` and `TextInput`) and `blurEvent` were simply aliases to `targetEvent` so defined `targetEvent` in `Event` and updated `TextInput` accordingly.

Added `onBlur` and `onFocus` props to `TouchableWithoutFeedback`.