### PR TITLE
Add children prop back to ImageBackground

### DIFF
--- a/reason-react-native/src/components/ImageBackground.md
+++ b/reason-react-native/src/components/ImageBackground.md
@@ -72,8 +72,10 @@ external make:
                    =?,
     ~source: Image.Source.t,
     ~style: Style.t=?,
-    ~testID: string=?
+    ~testID: string=?,
+    ~children: React.element=?
   ) =>
   React.element =
   "ImageBackground";
+  
 ```

--- a/reason-react-native/src/components/ImageBackground.re
+++ b/reason-react-native/src/components/ImageBackground.re
@@ -65,7 +65,8 @@ external make:
                    =?,
     ~source: Image.Source.t,
     ~style: Style.t=?,
-    ~testID: string=?
+    ~testID: string=?,
+    ~children: React.element=?
   ) =>
   React.element =
   "ImageBackground";


### PR DESCRIPTION
`ImageBackground` needs to have `children` as prop, otherwise offers nothing over `Image`.