### PR TITLE
Define type for onOrientationChange callback

### DIFF
--- a/reason-react-native/src/components/Modal.bs.js
+++ b/reason-react-native/src/components/Modal.bs.js
@@ -4,5 +4,8 @@ var NativeElement$ReactNative = require("../elements/NativeElement.bs.js");
 
 var Orientation = 0;
 
+var OrientationChange = 0;
+
 exports.Orientation = Orientation;
+exports.OrientationChange = OrientationChange;
 /* NativeElement-ReactNative Not a pure module */

--- a/reason-react-native/src/components/Modal.md
+++ b/reason-react-native/src/components/Modal.md
@@ -8,6 +8,7 @@ wip: true
 include NativeElement;
 
 module Orientation = Modal_Orientation;
+module OrientationChange = Modal_OrientationChange;
 
 [@react.component] [@bs.module "react-native"]
 external make:
@@ -17,7 +18,7 @@ external make:
     ~animationType: [@bs.string] [ | `none | `slide | `fade]=?,
     ~hardwareAccelerated: bool=?,
     ~onDismiss: unit => unit=?,
-    ~onOrientationChange: unit => unit=?,
+    ~onOrientationChange: Event.syntheticEvent({. "orientation": OrientationChange.t}) => unit=?,
     ~onRequestClose: unit => unit=?,
     ~onShow: unit => unit=?,
     ~presentationStyle: [@bs.string] [

--- a/reason-react-native/src/components/Modal.re
+++ b/reason-react-native/src/components/Modal.re
@@ -1,6 +1,7 @@
 include NativeElement;
 
 module Orientation = Modal_Orientation;
+module OrientationChange = Modal_OrientationChange;
 
 [@react.component] [@bs.module "react-native"]
 external make:
@@ -10,7 +11,7 @@ external make:
     ~animationType: [@bs.string] [ | `none | `slide | `fade]=?,
     ~hardwareAccelerated: bool=?,
     ~onDismiss: unit => unit=?,
-    ~onOrientationChange: unit => unit=?,
+    ~onOrientationChange: Event.syntheticEvent({. "orientation": OrientationChange.t}) => unit=?,
     ~onRequestClose: unit => unit=?,
     ~onShow: unit => unit=?,
     ~presentationStyle: [@bs.string] [

--- a/reason-react-native/src/types/Modal_OrientationChange.bs.js
+++ b/reason-react-native/src/types/Modal_OrientationChange.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/types/Modal_OrientationChange.re
+++ b/reason-react-native/src/types/Modal_OrientationChange.re
@@ -1,0 +1,7 @@
+type t = string;
+
+[@bs.inline]
+let landscape = "landscape";
+
+[@bs.inline]
+let portrait = "portrait";

--- a/reason-react-native/src/types/Modal_OrientationChange.rei
+++ b/reason-react-native/src/types/Modal_OrientationChange.rei
@@ -1,0 +1,7 @@
+type t;
+
+[@bs.inline "landscape"]
+let landscape: t;
+
+[@bs.inline "portrait"]
+let portrait: t;


### PR DESCRIPTION
`onOrientationChange` takes a function defined from a synthetic event wrapping an `orientation` key. However, allowed values for the key are only `portrait` and `landscape` so the existing type is not precise enough. To work around this, I added a new type named `eventValue` and two inlined values `landscape_` and `portrait_`.

Should we add `eventValue` or allow users to define actions in the callback for values which will never occur?
