### PR TITLE
Correct type for Button onPress callback, add nextFocus* props

### DIFF
--- a/reason-react-native/src/components/Button.md
+++ b/reason-react-native/src/components/Button.md
@@ -5,8 +5,7 @@ wip: true
 ---
 
 ```reason
-type element;
-type ref = React.Ref.t(Js.nullable(element));
+include NativeElement;
 
 [@react.component] [@bs.module "react-native"]
 external make:
@@ -17,7 +16,12 @@ external make:
     ~color: Color.t=?,
     ~disabled: bool=?,
     ~hasTVPreferredFocus: bool=?,
-    ~onPress: unit => unit,
+    ~nextFocusDown: int=?,
+    ~nextFocusForward: int=?,
+    ~nextFocusLeft: int=?,
+    ~nextFocusRight: int=?,
+    ~nextFocusUp: int=?,
+    ~onPress: Event.pressEvent => unit,
     ~testID: string=?,
     ~title: string
   ) =>

--- a/reason-react-native/src/components/Button.re
+++ b/reason-react-native/src/components/Button.re
@@ -9,7 +9,12 @@ external make:
     ~color: Color.t=?,
     ~disabled: bool=?,
     ~hasTVPreferredFocus: bool=?,
-    ~onPress: unit => unit,
+    ~nextFocusDown: int=?,
+    ~nextFocusForward: int=?,
+    ~nextFocusLeft: int=?,
+    ~nextFocusRight: int=?,
+    ~nextFocusUp: int=?,
+    ~onPress: Event.pressEvent => unit,
     ~testID: string=?,
     ~title: string
   ) =>


### PR DESCRIPTION
`nextFocus` props are Android-only whereas `hasTVPreferredFocus` is for AppleTV.