### PR TITLE
Add sendIntent to Linking

### DIFF
--- a/reason-react-native/src/apis/Linking.md
+++ b/reason-react-native/src/apis/Linking.md
@@ -5,6 +5,10 @@ wip: true
 ---
 
 ```reason
+type extra;
+
+[@bs.obj] external extra: (~key: string, ~value: 'a) => extra = "";
+
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external openURL: string => Js.Promise.t(unit) = "";
 
@@ -13,6 +17,14 @@ external canOpenURL: string => Js.Promise.t(bool) = "";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external getInitialURL: unit => Js.Promise.t(Js.Null.t(string)) = "";
+
+// multiple externals
+[@bs.scope "Linking"] [@bs.module "react-native"]
+external sendIntent: string => unit = "";
+
+// multiple externals
+[@bs.scope "Linking"] [@bs.module "react-native"]
+external sendIntentWithExtras: (string, array(extra)) => unit = "sendIntent";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external addEventListener:

--- a/reason-react-native/src/apis/Linking.re
+++ b/reason-react-native/src/apis/Linking.re
@@ -1,3 +1,7 @@
+type extra;
+
+[@bs.obj] external extra: (~key: string, ~value: 'a) => extra = "";
+
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external openURL: string => Js.Promise.t(unit) = "";
 
@@ -6,6 +10,14 @@ external canOpenURL: string => Js.Promise.t(bool) = "";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external getInitialURL: unit => Js.Promise.t(Js.Null.t(string)) = "";
+
+// multiple externals
+[@bs.scope "Linking"] [@bs.module "react-native"]
+external sendIntent: string => unit = "";
+
+// multiple externals
+[@bs.scope "Linking"] [@bs.module "react-native"]
+external sendIntentWithExtras: (string, array(extra)) => unit = "sendIntent";
 
 [@bs.scope "Linking"] [@bs.module "react-native"]
 external addEventListener:


### PR DESCRIPTION
I expected this to arrive in RN 0.60, but it's already in 0.59.8.

As previously discussed, I recommended and @cknitt agreed that it would be useful to add comments when we have multiple bindings to the same external function. With this PR, I'd also like to get your feedback on how the comment should read, before I propagate the change across the codebase.

I came up with `Convenience function` or `Duplicate` or `Duplicate Binding`.

@cknitt @MoOx any preferences?
