### PR TITLE
Add constructor for jsValue, add comments for multiple externals

### DIFF
--- a/reason-react-native/src/apis/Animated.md
+++ b/reason-react-native/src/apis/Animated.md
@@ -202,6 +202,8 @@ module ValueXY = {
     };
   });
 
+  [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue = "";
+
   type translateTransform = {
     .
     "translateX": Value.t,
@@ -236,9 +238,11 @@ type loopConfig;
 
 [@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loop: Animation.t => Animation.t = "";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 

--- a/reason-react-native/src/apis/Animated.re
+++ b/reason-react-native/src/apis/Animated.re
@@ -195,6 +195,8 @@ module ValueXY = {
     };
   });
 
+  [@bs.obj] external jsValue: (~x: float, ~y: float) => jsValue = "";
+
   type translateTransform = {
     .
     "translateX": Value.t,
@@ -229,9 +231,11 @@ type loopConfig;
 
 [@bs.obj] external loopConfig: (~iterations: int) => loopConfig = "";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loop: Animation.t => Animation.t = "";
 
+// multiple externals
 [@bs.module "react-native"] [@bs.scope "Animated"]
 external loopWithConfig: (Animation.t, loopConfig) => Animation.t = "loop";
 


### PR DESCRIPTION
`jsValue` is to be consumed in callbacks, but also needs to be created to pass as parameters to `ValueXY` animations and for ValueXY methods. This is similar to #486 as the type needs to be created as well as consumed.

While addressing this issue, I also added comments to indicate multiple externals.