### PR TITLE
UIManager API

### DIFF
--- a/reason-react-native/src/apis/UIManager.bs.js
+++ b/reason-react-native/src/apis/UIManager.bs.js
@@ -1,0 +1,1 @@
+/* This output is empty. Its source's type definitions, externals and/or unused code got optimized away. */

--- a/reason-react-native/src/apis/UIManager.md
+++ b/reason-react-native/src/apis/UIManager.md
@@ -1,0 +1,48 @@
+---
+id: apis/UIManager
+title: UIManager
+wip: true
+---
+
+```reason
+type popupAction;
+
+[@bs.module "react-native"] [@bs.scope ("UIManager", "PopupMenu")]
+external itemSelected: popupAction = "";
+
+[@bs.module "react-native"] [@bs.scope ("UIManager", "PopupMenu")]
+external dismissed: popupAction = "";
+
+// Android-only. This function is intended to be removed in the future,
+// at which point it would return undefined. Accordingly it is wrapped in
+// option.
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external setLayoutAnimationEnabledExperimental: option(bool => unit) = "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external showPopupMenu:
+  (
+    int,
+    array(string),
+    ~onError: unit => unit,
+    ~onSuccess: (popupAction, option(int)) => unit
+  ) =>
+  unit =
+  "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external dismissPopupMenu: unit => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external setJSResponder: (int, bool) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external clearJSResponder: unit => unit = "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external playTouchSound: unit => unit = "";
+
+```

--- a/reason-react-native/src/apis/UIManager.re
+++ b/reason-react-native/src/apis/UIManager.re
@@ -1,0 +1,39 @@
+type popupAction;
+
+[@bs.module "react-native"] [@bs.scope ("UIManager", "PopupMenu")]
+external itemSelected: popupAction = "";
+
+[@bs.module "react-native"] [@bs.scope ("UIManager", "PopupMenu")]
+external dismissed: popupAction = "";
+
+// Android-only. This function is intended to be removed in the future,
+// at which point it would return undefined. Accordingly it is wrapped in
+// option.
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external setLayoutAnimationEnabledExperimental: option(bool => unit) = "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external showPopupMenu:
+  (
+    int,
+    array(string),
+    ~onError: unit => unit,
+    ~onSuccess: (popupAction, option(int)) => unit
+  ) =>
+  unit =
+  "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external dismissPopupMenu: unit => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external setJSResponder: (int, bool) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external clearJSResponder: unit => unit = "";
+
+// Android-only
+[@bs.module "react-native"] [@bs.scope "UIManager"]
+external playTouchSound: unit => unit = "";


### PR DESCRIPTION
Relates to #483 

This is an incomplete implementation of methods in `UIManager` but enabling `LayoutAnimation` and showing and dismissing popups on Android are included.

`setJSResponder` and `clearJSResponder` are for finer grained control of which component should be the gesture responder (such as for creating a swipable element in a `ScrollView`).

Some of the other methods have already been covered elsewhere - such as `measure` in `NativeMethods` and therefore omitted, but I will revisit this if I'm able to document other methods.