### PR TITLE
Revise PermissionsAndroid API

### DIFF
--- a/reason-react-native/src/apis/PermissionsAndroid.bs.js
+++ b/reason-react-native/src/apis/PermissionsAndroid.bs.js
@@ -3,5 +3,8 @@
 
 var Permission = /* module */[];
 
+var Result = /* module */[];
+
 exports.Permission = Permission;
+exports.Result = Result;
 /* No side effect */

--- a/reason-react-native/src/apis/PermissionsAndroid.md
+++ b/reason-react-native/src/apis/PermissionsAndroid.md
@@ -8,79 +8,114 @@ wip: true
 module Permission: {
   type t;
 
-  [@bs.inline "READ_CALENDAR"]
-  let readCalendar: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCalendar: t = "READ_CALENDAR";
 
-  [@bs.inline "WRITE_CALENDAR"]
-  let writeCalendar: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCalendar: t = "WRITE_CALENDAR";
 
-  [@bs.inline "CAMERA"]
-  let camera: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external camera: t = "CAMERA";
 
-  [@bs.inline "READ_CONTACTS"]
-  let readContacts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readContacts: t = "READ_CONTACTS";
 
-  [@bs.inline "WRITE_CONTACTS"]
-  let writeContacts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeContacts: t = "WRITE_CONTACTS";
 
-  [@bs.inline "GET_ACCOUNTS"]
-  let getAccounts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external getAccounts: t = "GET_ACCOUNTS";
 
-  [@bs.inline "ACCESS_FINE_LOCATION"]
-  let accessFineLocation: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessFineLocation: t = "ACCESS_FINE_LOCATION";
 
-  [@bs.inline "ACCESS_COARSE_LOCATION"]
-  let accessCoarseLocation: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessCoarseLocation: t = "ACCESS_COARSE_LOCATION";
 
-  [@bs.inline "RECORD_AUDIO"]
-  let recordAudio: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external recordAudio: t = "RECORD_AUDIO";
 
-  [@bs.inline "READ_PHONE_STATE"]
-  let readPhoneState: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readPhoneState: t = "READ_PHONE_STATE";
 
-  [@bs.inline "CALL_PHONE"]
-  let callPhone: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external callPhone: t = "CALL_PHONE";
 
-  [@bs.inline "READ_CALL_LOG"]
-  let readCallLog: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCallLog: t = "READ_CALL_LOG";
 
-  [@bs.inline "WRITE_CALL_LOG"]
-  let writeCallLog: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCallLog: t = "WRITE_CALL_LOG";
 
-  [@bs.inline "ADD_VOICEMAIL"]
-  let addVoicemail: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external addVoicemail: t = "ADD_VOICEMAIL";
 
-  [@bs.inline "USE_SIP"]
-  let useSip: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external useSip: t = "USE_SIP";
 
-  [@bs.inline "PROCESS_OUTGOING_CALLS"]
-  let processOutgoingCalls: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external processOutgoingCalls: t = "PROCESS_OUTGOING_CALLS";
 
-  [@bs.inline "BODY_SENSORS"]
-  let bodySensors: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external bodySensors: t = "BODY_SENSORS";
 
-  [@bs.inline "SEND_SMS"]
-  let sendSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external sendSms: t = "SEND_SMS";
 
-  [@bs.inline "RECEIVE_SMS"]
-  let receiveSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveSms: t = "RECEIVE_SMS";
 
-  [@bs.inline "READ_SMS"]
-  let readSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readSms: t = "READ_SMS";
 
-  [@bs.inline "RECEIVE_WAP_PUSH"]
-  let receiveWapPush: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveWapPush: t = "RECEIVE_WAP_PUSH";
 
-  [@bs.inline "RECEIVE_MMS"]
-  let receiveMms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveMms: t = "RECEIVE_MMS";
 
-  [@bs.inline "READ_EXTERNAL_STORAGE"]
-  let readExternalStorage: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readExternalStorage: t = "READ_EXTERNAL_STORAGE";
 
-  [@bs.inline "WRITE_EXTERNAL_STORAGE"]
-  let writeExternalStorage: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeExternalStorage: t = "WRITE_EXTERNAL_STORAGE";
+};
 
-  external toString: t => string = "%identity";
+module Result: {
+  type t;
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external granted: t = "GRANTED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external denied: t = "DENIED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external neverAskAgain: t = "NEVER_ASK_AGAIN";
 };
 
 type rationale;
@@ -97,23 +132,24 @@ external rationale:
   rationale =
   "";
 
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external check: Permission.t => Js.Promise.t(Js.Null.t(bool)) = "";
+type dict;
+
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external check: Permission.t => Js.Promise.t(bool) = "check";
 
 // multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external request: Permission.t => Js.Promise.t(Js.Null.t(string)) = "";
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external request: Permission.t => Js.Promise.t(Result.t) = "";
 
 // multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
 external requestWithRationale:
-  (Permission.t, rationale) => Js.Promise.t(Js.Null.t(string)) =
+  (Permission.t, rationale) => Js.Promise.t(Result.t) =
   "request";
 
-// multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external requestMultiple:
-  array(Permission.t) => Js.Promise.t(Js.Dict.t(string)) =
-  "request";
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external requestMultiple: array(Permission.t) => Js.Promise.t(dict) = "";
+
+[@bs.get_index] external get: (dict, Permission.t) => option(Result.t) = "";
   
 ```

--- a/reason-react-native/src/apis/PermissionsAndroid.re
+++ b/reason-react-native/src/apis/PermissionsAndroid.re
@@ -1,79 +1,114 @@
 module Permission = {
   type t = string;
 
-  [@bs.inline]
-  let readCalendar = "READ_CALENDAR";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCalendar: t = "READ_CALENDAR";
 
-  [@bs.inline]
-  let writeCalendar = "WRITE_CALENDAR";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCalendar: t = "WRITE_CALENDAR";
 
-  [@bs.inline]
-  let camera = "CAMERA";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external camera: t = "CAMERA";
 
-  [@bs.inline]
-  let readContacts = "READ_CONTACTS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readContacts: t = "READ_CONTACTS";
 
-  [@bs.inline]
-  let writeContacts = "WRITE_CONTACTS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeContacts: t = "WRITE_CONTACTS";
 
-  [@bs.inline]
-  let getAccounts = "GET_ACCOUNTS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external getAccounts: t = "GET_ACCOUNTS";
 
-  [@bs.inline]
-  let accessFineLocation = "ACCESS_FINE_LOCATION";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessFineLocation: t = "ACCESS_FINE_LOCATION";
 
-  [@bs.inline]
-  let accessCoarseLocation = "ACCESS_COARSE_LOCATION";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessCoarseLocation: t = "ACCESS_COARSE_LOCATION";
 
-  [@bs.inline]
-  let recordAudio = "RECORD_AUDIO";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external recordAudio: t = "RECORD_AUDIO";
 
-  [@bs.inline]
-  let readPhoneState = "READ_PHONE_STATE";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readPhoneState: t = "READ_PHONE_STATE";
 
-  [@bs.inline]
-  let callPhone = "CALL_PHONE";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external callPhone: t = "CALL_PHONE";
 
-  [@bs.inline]
-  let readCallLog = "READ_CALL_LOG";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCallLog: t = "READ_CALL_LOG";
 
-  [@bs.inline]
-  let writeCallLog = "WRITE_CALL_LOG";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCallLog: t = "WRITE_CALL_LOG";
 
-  [@bs.inline]
-  let addVoicemail = "ADD_VOICEMAIL";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external addVoicemail: t = "ADD_VOICEMAIL";
 
-  [@bs.inline]
-  let useSip = "USE_SIP";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external useSip: t = "USE_SIP";
 
-  [@bs.inline]
-  let processOutgoingCalls = "PROCESS_OUTGOING_CALLS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external processOutgoingCalls: t = "PROCESS_OUTGOING_CALLS";
 
-  [@bs.inline]
-  let bodySensors = "BODY_SENSORS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external bodySensors: t = "BODY_SENSORS";
 
-  [@bs.inline]
-  let sendSms = "SEND_SMS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external sendSms: t = "SEND_SMS";
 
-  [@bs.inline]
-  let receiveSms = "RECEIVE_SMS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveSms: t = "RECEIVE_SMS";
 
-  [@bs.inline]
-  let readSms = "READ_SMS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readSms: t = "READ_SMS";
 
-  [@bs.inline]
-  let receiveWapPush = "RECEIVE_WAP_PUSH";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveWapPush: t = "RECEIVE_WAP_PUSH";
 
-  [@bs.inline]
-  let receiveMms = "RECEIVE_MMS";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveMms: t = "RECEIVE_MMS";
 
-  [@bs.inline]
-  let readExternalStorage = "READ_EXTERNAL_STORAGE";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readExternalStorage: t = "READ_EXTERNAL_STORAGE";
 
-  [@bs.inline]
-  let writeExternalStorage = "WRITE_EXTERNAL_STORAGE";
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeExternalStorage: t = "WRITE_EXTERNAL_STORAGE";
+};
 
-  external toString: t => string = "%identity";
+module Result = {
+  type t;
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external granted: t = "GRANTED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external denied: t = "DENIED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external neverAskAgain: t = "NEVER_ASK_AGAIN";
 };
 
 type rationale;
@@ -90,21 +125,22 @@ external rationale:
   rationale =
   "";
 
+type dict = Js.Dict.t(Result.t);
+
 [@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
-external check: Permission.t => Js.Promise.t(Js.Null.t(bool)) = "";
+external check: Permission.t => Js.Promise.t(bool) = "check";
 
 // multiple externals
 [@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
-external request: Permission.t => Js.Promise.t(Js.Null.t(string)) = "";
+external request: Permission.t => Js.Promise.t(Result.t) = "";
 
 // multiple externals
 [@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
 external requestWithRationale:
-  (Permission.t, rationale) => Js.Promise.t(Js.Null.t(string)) =
+  (Permission.t, rationale) => Js.Promise.t(Result.t) =
   "request";
 
-// multiple externals
 [@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
-external requestMultiple:
-  array(Permission.t) => Js.Promise.t(Js.Dict.t(string)) =
-  "request";
+external requestMultiple: array(Permission.t) => Js.Promise.t(dict) = "";
+
+[@bs.get_index] external get: (dict, Permission.t) => option(Result.t) = "";

--- a/reason-react-native/src/apis/PermissionsAndroid.rei
+++ b/reason-react-native/src/apis/PermissionsAndroid.rei
@@ -1,79 +1,114 @@
 module Permission: {
   type t;
 
-  [@bs.inline "READ_CALENDAR"]
-  let readCalendar: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCalendar: t = "READ_CALENDAR";
 
-  [@bs.inline "WRITE_CALENDAR"]
-  let writeCalendar: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCalendar: t = "WRITE_CALENDAR";
 
-  [@bs.inline "CAMERA"]
-  let camera: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external camera: t = "CAMERA";
 
-  [@bs.inline "READ_CONTACTS"]
-  let readContacts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readContacts: t = "READ_CONTACTS";
 
-  [@bs.inline "WRITE_CONTACTS"]
-  let writeContacts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeContacts: t = "WRITE_CONTACTS";
 
-  [@bs.inline "GET_ACCOUNTS"]
-  let getAccounts: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external getAccounts: t = "GET_ACCOUNTS";
 
-  [@bs.inline "ACCESS_FINE_LOCATION"]
-  let accessFineLocation: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessFineLocation: t = "ACCESS_FINE_LOCATION";
 
-  [@bs.inline "ACCESS_COARSE_LOCATION"]
-  let accessCoarseLocation: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external accessCoarseLocation: t = "ACCESS_COARSE_LOCATION";
 
-  [@bs.inline "RECORD_AUDIO"]
-  let recordAudio: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external recordAudio: t = "RECORD_AUDIO";
 
-  [@bs.inline "READ_PHONE_STATE"]
-  let readPhoneState: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readPhoneState: t = "READ_PHONE_STATE";
 
-  [@bs.inline "CALL_PHONE"]
-  let callPhone: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external callPhone: t = "CALL_PHONE";
 
-  [@bs.inline "READ_CALL_LOG"]
-  let readCallLog: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readCallLog: t = "READ_CALL_LOG";
 
-  [@bs.inline "WRITE_CALL_LOG"]
-  let writeCallLog: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeCallLog: t = "WRITE_CALL_LOG";
 
-  [@bs.inline "ADD_VOICEMAIL"]
-  let addVoicemail: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external addVoicemail: t = "ADD_VOICEMAIL";
 
-  [@bs.inline "USE_SIP"]
-  let useSip: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external useSip: t = "USE_SIP";
 
-  [@bs.inline "PROCESS_OUTGOING_CALLS"]
-  let processOutgoingCalls: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external processOutgoingCalls: t = "PROCESS_OUTGOING_CALLS";
 
-  [@bs.inline "BODY_SENSORS"]
-  let bodySensors: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external bodySensors: t = "BODY_SENSORS";
 
-  [@bs.inline "SEND_SMS"]
-  let sendSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external sendSms: t = "SEND_SMS";
 
-  [@bs.inline "RECEIVE_SMS"]
-  let receiveSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveSms: t = "RECEIVE_SMS";
 
-  [@bs.inline "READ_SMS"]
-  let readSms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readSms: t = "READ_SMS";
 
-  [@bs.inline "RECEIVE_WAP_PUSH"]
-  let receiveWapPush: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveWapPush: t = "RECEIVE_WAP_PUSH";
 
-  [@bs.inline "RECEIVE_MMS"]
-  let receiveMms: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external receiveMms: t = "RECEIVE_MMS";
 
-  [@bs.inline "READ_EXTERNAL_STORAGE"]
-  let readExternalStorage: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external readExternalStorage: t = "READ_EXTERNAL_STORAGE";
 
-  [@bs.inline "WRITE_EXTERNAL_STORAGE"]
-  let writeExternalStorage: t;
+  [@bs.module "react-native"]
+  [@bs.scope ("PermissionsAndroid", "PERMISSIONS")]
+  external writeExternalStorage: t = "WRITE_EXTERNAL_STORAGE";
+};
 
-  external toString: t => string = "%identity";
+module Result: {
+  type t;
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external granted: t = "GRANTED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external denied: t = "DENIED";
+
+  [@bs.module "react-native"] [@bs.scope ("PermissionsAndroid", "RESULTS")]
+  external neverAskAgain: t = "NEVER_ASK_AGAIN";
 };
 
 type rationale;
@@ -90,21 +125,22 @@ external rationale:
   rationale =
   "";
 
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external check: Permission.t => Js.Promise.t(Js.Null.t(bool)) = "";
+type dict;
+
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external check: Permission.t => Js.Promise.t(bool) = "check";
 
 // multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external request: Permission.t => Js.Promise.t(Js.Null.t(string)) = "";
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external request: Permission.t => Js.Promise.t(Result.t) = "";
 
 // multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
 external requestWithRationale:
-  (Permission.t, rationale) => Js.Promise.t(Js.Null.t(string)) =
+  (Permission.t, rationale) => Js.Promise.t(Result.t) =
   "request";
 
-// multiple externals
-[@bs.module "react-native"] [@bs.scope "PermissionsAndroid"]
-external requestMultiple:
-  array(Permission.t) => Js.Promise.t(Js.Dict.t(string)) =
-  "request";
+[@bs.scope "PermissionsAndroid"] [@bs.module "react-native"]
+external requestMultiple: array(Permission.t) => Js.Promise.t(dict) = "";
+
+[@bs.get_index] external get: (dict, Permission.t) => option(Result.t) = "";


### PR DESCRIPTION
I noticed that the return types for the methods should simply be wrapped in `Js.Promise.t` and could not be `null`. I also corrected a few other issues such as `requestMultiple` being distinct from `request`.

Instead of using `[@bs.inline]` to generate strings, I defined bindings to the exposed constants.

As `Js.Dict` requires keys to be `string`, to avoid exposing that `Permission.t` is a `string`, I defined
```
type dict = Js.Dict.t(Result.t);
[@bs.get_index] external get: (dict, Permission.t) => Result.t = "";
``` 
The latter is similar to the definition of `Js.Dict.unsafeGet` in the standard `BuckleScript` library. However, as all the keys are predetermined, we should not have any issues with the function returning a `null` or `undefined`.