### PR TITLE
Add comment for VirtualizedList props not supported by FlatList

### DIFF
--- a/reason-react-native/src/components/FlatList.md
+++ b/reason-react-native/src/components/FlatList.md
@@ -5,6 +5,10 @@ wip: true
 ---
 
 ```reason
+// VirtualizedList props data, getItem, getItemCount and getItemLayout
+// are not supported on FlatList
+// FlatList has its own data prop, specified as array(item)
+
 include VirtualizedListElement;
 
 type separatorComponentProps('item) = {

--- a/reason-react-native/src/components/FlatList.re
+++ b/reason-react-native/src/components/FlatList.re
@@ -1,3 +1,7 @@
+// VirtualizedList props data, getItem, getItemCount and getItemLayout
+// are not supported on FlatList
+// FlatList has its own data prop, specified as array(item)
+
 include VirtualizedListElement;
 
 type separatorComponentProps('item) = {


### PR DESCRIPTION
`getItem` and `getItemCount` are both illegal. They are already not enabled (commented out), this PR removes them for good. For reference, RN is supposed to throw an error whenever either prop is passed to `FlatList`, as below:
```
invariant(
      !getItem && !getItemCount,
      'FlatList does not support custom data formats.',
    );
```

Further, `data` prop cannot be any type, but must be an array.

Finally, it seems `_CellRendererComponent` can be enabled (this I did not test)