### PR TITLE
add methods to StatusBar

### DIFF
--- a/reason-react-native/src/components/StatusBar.md
+++ b/reason-react-native/src/components/StatusBar.md
@@ -24,4 +24,30 @@ external make:
   React.element =
   "StatusBar";
 
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setHidden: (bool, [@bs.string] [ | `none | `fade | `slide]) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setBarStyle:
+  (
+    [@bs.string] [
+      | `default
+      | [@bs.as "light-content"] `lightContent
+      | [@bs.as "dark-content"] `darkContent
+    ],
+    bool
+  ) =>
+  unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setNetworkActivityIndicatorVisible: bool => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setBackgroundColor: (Color.t, bool) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setTranslucent: bool => unit = "";
+
 ```

--- a/reason-react-native/src/components/StatusBar.re
+++ b/reason-react-native/src/components/StatusBar.re
@@ -16,3 +16,29 @@ external make:
   ) =>
   React.element =
   "StatusBar";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setHidden: (bool, [@bs.string] [ | `none | `fade | `slide]) => unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setBarStyle:
+  (
+    [@bs.string] [
+      | `default
+      | [@bs.as "light-content"] `lightContent
+      | [@bs.as "dark-content"] `darkContent
+    ],
+    bool
+  ) =>
+  unit =
+  "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setNetworkActivityIndicatorVisible: bool => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setBackgroundColor: (Color.t, bool) => unit = "";
+
+[@bs.module "react-native"] [@bs.scope "StatusBar"]
+external setTranslucent: bool => unit = "";


### PR DESCRIPTION
Adding methods (referred to as the imperative API in documentation)

For the `setHidden` method, animation style (`` `none``,  `` `slide``, `` `fade``) is an optional argument whereas for `setBarStyle` `animated` (boolean) is an optional argument, but I figured adding multiple functions or making those optional arguments would be more verbose than simply requiring the additional argument.