### PR TITLE
Style: Add unsafeAddStyle, unsafeStyle & unsafeTransform as escape hatch

### DIFF
--- a/reason-react-native/src/apis/Style.bs.js
+++ b/reason-react-native/src/apis/Style.bs.js
@@ -1,10 +1,8 @@
 'use strict';
 
 
-function unsafeAddProp(style, property, value) {
-  var o = Object.assign({ }, style);
-  o[property] = value;
-  return o;
+function unsafeAddStyle(style, styles) {
+  return Object.assign({ }, style, styles);
 }
 
 function pct(num) {
@@ -19,15 +17,8 @@ function rad(num) {
   return num.toString() + "rad";
 }
 
-function unsafeTransform(prop, value) {
-  var tf = { };
-  tf[prop] = value;
-  return tf;
-}
-
-exports.unsafeAddProp = unsafeAddProp;
+exports.unsafeAddStyle = unsafeAddStyle;
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;
-exports.unsafeTransform = unsafeTransform;
 /* No side effect */

--- a/reason-react-native/src/apis/Style.bs.js
+++ b/reason-react-native/src/apis/Style.bs.js
@@ -1,10 +1,6 @@
 'use strict';
 
 
-function unsafeAddStyle(style, styles) {
-  return Object.assign({ }, style, styles);
-}
-
 function pct(num) {
   return num.toString() + "%";
 }
@@ -17,7 +13,6 @@ function rad(num) {
   return num.toString() + "rad";
 }
 
-exports.unsafeAddStyle = unsafeAddStyle;
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;

--- a/reason-react-native/src/apis/Style.bs.js
+++ b/reason-react-native/src/apis/Style.bs.js
@@ -1,6 +1,12 @@
 'use strict';
 
 
+function unsafeAddProp(style, property, value) {
+  var o = Object.assign({ }, style);
+  o[property] = value;
+  return o;
+}
+
 function pct(num) {
   return num.toString() + "%";
 }
@@ -13,7 +19,15 @@ function rad(num) {
   return num.toString() + "rad";
 }
 
+function unsafeTransform(prop, value) {
+  var tf = { };
+  tf[prop] = value;
+  return tf;
+}
+
+exports.unsafeAddProp = unsafeAddProp;
 exports.pct = pct;
 exports.deg = deg;
 exports.rad = rad;
+exports.unsafeTransform = unsafeTransform;
 /* No side effect */

--- a/reason-react-native/src/apis/Style.re
+++ b/reason-react-native/src/apis/Style.re
@@ -1,5 +1,22 @@
 type t;
 
+external array: array(t) => t = "%identity";
+external arrayOption: array(option(t)) => t = "%identity";
+/* list works too since RN accept recursive array of styles (ocaml list are recursive arrays in JS)*/
+external list: list(t) => t = "%identity";
+external listOption: list(option(t)) => t = "%identity";
+
+// Escape hatch, in case something is added into RN but unsupported,
+// Useful if you play with fancy platforms
+// Use with caution
+let unsafeAddProp: (t, string, string) => t =
+  (style, property, value) => {
+    let o =
+      Js.Dict.empty()->Obj.magic->Js.Obj.assign(style->Obj.magic)->Obj.magic;
+    o->Js.Dict.set(property, value);
+    o->Obj.magic;
+  };
+
 type size = string;
 
 external pt: float => size = "%identity";
@@ -32,6 +49,13 @@ type transform;
 [@bs.obj] external skewX: (~skewX: angle) => transform = "";
 [@bs.obj] external skewY: (~skewY: angle) => transform = "";
 // @todo matrix
+
+let unsafeTransform: (string, string) => transform =
+  (prop, value) => {
+    let tf = Js.Dict.empty();
+    tf->Js.Dict.set(prop, value);
+    tf->Obj.magic;
+  };
 
 [@bs.obj]
 // Layout Props (https://facebook.github.io/react-native/docs/layout-props#props)
@@ -222,40 +246,3 @@ external style:
   ) =>
   t =
   "";
-
-/*
- <View style=array([|
-   styles##thing,
-   styles##whatever,
- |])>
-   */
-external array: array(t) => t = "%identity";
-
-/*
- <View style=arrayOption([|
-   Some(styles##thing),
-   Some(styles##whatever),
-   optionalStyle,
-   cond ? Some({something:"dynamic"}) : None
- |])>
- */
-external arrayOption: array(option(t)) => t = "%identity";
-
-/* list works too since RN accept recursive array of styles (list are just recursive arrays)*/
-/*
- <View style=list([
-   styles##thing,
-   styles##whatever,
- ])>
-   */
-external list: list(t) => t = "%identity";
-
-/*
- <View style=listOption([
-   Some(styles##thing),
-   Some(styles##whatever),
-   optionalStyle,
-   cond ? Some({something:"dynamic"}) : None
- ])>
- */
-external listOption: list(option(t)) => t = "%identity";

--- a/reason-react-native/src/apis/Style.re
+++ b/reason-react-native/src/apis/Style.re
@@ -9,13 +9,12 @@ external listOption: list(option(t)) => t = "%identity";
 // Escape hatch, in case something is added into RN but unsupported,
 // Useful if you play with fancy platforms
 // Use with caution
-let unsafeAddProp: (t, string, string) => t =
-  (style, property, value) => {
-    let o =
-      Js.Dict.empty()->Obj.magic->Js.Obj.assign(style->Obj.magic)->Obj.magic;
-    o->Js.Dict.set(property, value);
-    o->Obj.magic;
-  };
+[@bs.val]
+external unsafeAddStyle_: (Js.Dict.t('a), t, 'b) => t = "Object.assign";
+let unsafeAddStyle: (t, Js.t('a)) => t =
+  (style, styles) => unsafeAddStyle_(Js.Dict.empty(), style, styles);
+
+external unsafeStyle: Js.t('a) => t = "%identity";
 
 type size = string;
 
@@ -50,12 +49,7 @@ type transform;
 [@bs.obj] external skewY: (~skewY: angle) => transform = "";
 // @todo matrix
 
-let unsafeTransform: (string, string) => transform =
-  (prop, value) => {
-    let tf = Js.Dict.empty();
-    tf->Js.Dict.set(prop, value);
-    tf->Obj.magic;
-  };
+external unsafeTransform: Js.t('a) => transform = "%identity";
 
 [@bs.obj]
 // Layout Props (https://facebook.github.io/react-native/docs/layout-props#props)

--- a/reason-react-native/src/apis/Style.re
+++ b/reason-react-native/src/apis/Style.re
@@ -10,9 +10,8 @@ external listOption: list(option(t)) => t = "%identity";
 // Useful if you play with fancy platforms
 // Use with caution
 [@bs.val]
-external unsafeAddStyle_: (Js.Dict.t('a), t, 'b) => t = "Object.assign";
-let unsafeAddStyle: (t, Js.t('a)) => t =
-  (style, styles) => unsafeAddStyle_(Js.Dict.empty(), style, styles);
+external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
+  "Object.assign";
 
 external unsafeStyle: Js.t('a) => t = "%identity";
 

--- a/reason-react-native/src/apis/Style.rei
+++ b/reason-react-native/src/apis/Style.rei
@@ -4,7 +4,9 @@ external array: array(t) => t = "%identity";
 external arrayOption: array(option(t)) => t = "%identity";
 external list: list(t) => t = "%identity";
 external listOption: list(option(t)) => t = "%identity";
-let unsafeAddStyle: (t, Js.t('a)) => t;
+[@bs.val]
+external unsafeAddStyle: ([@bs.as {json|{}|json}] _, t, Js.t('a)) => t =
+  "Object.assign";
 external unsafeStyle: Js.t('a) => t = "%identity";
 
 type size;

--- a/reason-react-native/src/apis/Style.rei
+++ b/reason-react-native/src/apis/Style.rei
@@ -4,7 +4,8 @@ external array: array(t) => t = "%identity";
 external arrayOption: array(option(t)) => t = "%identity";
 external list: list(t) => t = "%identity";
 external listOption: list(option(t)) => t = "%identity";
-let unsafeAddProp: (t, string, string) => t;
+let unsafeAddStyle: (t, Js.t('a)) => t;
+external unsafeStyle: Js.t('a) => t = "%identity";
 
 type size;
 
@@ -39,7 +40,7 @@ type transform;
 [@bs.obj] external skewY: (~skewY: angle) => transform = "";
 // @todo matrix
 
-let unsafeTransform: (string, string) => transform;
+external unsafeTransform: Js.t('a) => transform = "%identity";
 
 [@bs.obj]
 // Layout Props (https://facebook.github.io/react-native/docs/layout-props#props)

--- a/reason-react-native/src/apis/Style.rei
+++ b/reason-react-native/src/apis/Style.rei
@@ -1,5 +1,11 @@
 type t;
 
+external array: array(t) => t = "%identity";
+external arrayOption: array(option(t)) => t = "%identity";
+external list: list(t) => t = "%identity";
+external listOption: list(option(t)) => t = "%identity";
+let unsafeAddProp: (t, string, string) => t;
+
 type size;
 
 external pt: float => size = "%identity";
@@ -32,6 +38,8 @@ type transform;
 [@bs.obj] external skewX: (~skewX: angle) => transform = "";
 [@bs.obj] external skewY: (~skewY: angle) => transform = "";
 // @todo matrix
+
+let unsafeTransform: (string, string) => transform;
 
 [@bs.obj]
 // Layout Props (https://facebook.github.io/react-native/docs/layout-props#props)
@@ -222,40 +230,3 @@ external style:
   ) =>
   t =
   "";
-
-/*
- <View style=array([|
-   styles##thing,
-   styles##whatever,
- |])>
-   */
-external array: array(t) => t = "%identity";
-
-/*
- <View style=arrayOption([|
-   Some(styles##thing),
-   Some(styles##whatever),
-   optionalStyle,
-   cond ? Some({something:"dynamic"}) : None
- |])>
- */
-external arrayOption: array(option(t)) => t = "%identity";
-
-/* list works too since RN accept recursive array of styles (list are just recursive arrays)*/
-/*
- <View style=list([
-   styles##thing,
-   styles##whatever,
- ])>
-   */
-external list: list(t) => t = "%identity";
-
-/*
- <View style=listOption([
-   Some(styles##thing),
-   Some(styles##whatever),
-   optionalStyle,
-   cond ? Some({something:"dynamic"}) : None
- ])>
- */
-external listOption: list(option(t)) => t = "%identity";


### PR DESCRIPTION
…for fancy platforms!

(and move array/list(Option) at the top - without huge comments)

This escape hatch are a necessity when using react-native-web (eg: position: fixed on the web - as you cannot always have 60fps sticky header with interpolation+translateY... Also RNW allows `translateZ`etc...)