### PR TITLE
fix type for Gesture Responder onResponderTerminationRequest handler

### DIFF
--- a/bs-react-native-jsx3-compat/src/panResponder.rei
+++ b/bs-react-native-jsx3-compat/src/panResponder.rei
@@ -144,7 +144,7 @@ reference {b Types.touchResponderHandlers}
   onResponderReject: option(RNEvent.NativeEvent.t => unit),
   onResponderRelease: option(RNEvent.NativeEvent.t => unit),
   onResponderTerminate: option(RNEvent.NativeEvent.t => unit),
-  onResponderTerminationRequest: option(RNEvent.NativeEvent.t => unit),
+  onResponderTerminationRequest: option(RNEvent.NativeEvent.t => bool),
   onStartShouldSetResponder: option(RNEvent.NativeEvent.t => bool),
   onStartShouldSetResponderCapture: option(RNEvent.NativeEvent.t => bool),
 };

--- a/bs-react-native-jsx3-compat/src/types.re
+++ b/bs-react-native-jsx3-compat/src/types.re
@@ -26,7 +26,7 @@ type touchResponderHandlers = {
   onResponderReject: option(RNEvent.NativeEvent.t => unit),
   onResponderRelease: option(RNEvent.NativeEvent.t => unit),
   onResponderTerminate: option(RNEvent.NativeEvent.t => unit),
-  onResponderTerminationRequest: option(RNEvent.NativeEvent.t => unit),
+  onResponderTerminationRequest: option(RNEvent.NativeEvent.t => bool),
   onStartShouldSetResponder: option(RNEvent.NativeEvent.t => bool),
   onStartShouldSetResponderCapture: option(RNEvent.NativeEvent.t => bool),
 };

--- a/reason-react-native/src/components/ActivityIndicator.md
+++ b/reason-react-native/src/components/ActivityIndicator.md
@@ -75,7 +75,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ActivityIndicator.re
+++ b/reason-react-native/src/components/ActivityIndicator.re
@@ -68,7 +68,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/CheckBox.md
+++ b/reason-react-native/src/components/CheckBox.md
@@ -80,7 +80,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/CheckBox.re
+++ b/reason-react-native/src/components/CheckBox.re
@@ -73,7 +73,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/DatePickerIOS.md
+++ b/reason-react-native/src/components/DatePickerIOS.md
@@ -91,7 +91,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/DatePickerIOS.re
+++ b/reason-react-native/src/components/DatePickerIOS.re
@@ -84,7 +84,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/DrawerLayoutAndroid.md
+++ b/reason-react-native/src/components/DrawerLayoutAndroid.md
@@ -96,7 +96,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/DrawerLayoutAndroid.re
+++ b/reason-react-native/src/components/DrawerLayoutAndroid.re
@@ -89,7 +89,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/FlatList.md
+++ b/reason-react-native/src/components/FlatList.md
@@ -177,7 +177,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/FlatList.re
+++ b/reason-react-native/src/components/FlatList.re
@@ -170,7 +170,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/KeyboardAvoidingView.md
+++ b/reason-react-native/src/components/KeyboardAvoidingView.md
@@ -72,7 +72,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/KeyboardAvoidingView.re
+++ b/reason-react-native/src/components/KeyboardAvoidingView.re
@@ -65,7 +65,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/MaskedViewIOS.md
+++ b/reason-react-native/src/components/MaskedViewIOS.md
@@ -70,7 +70,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/MaskedViewIOS.re
+++ b/reason-react-native/src/components/MaskedViewIOS.re
@@ -63,7 +63,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Picker.md
+++ b/reason-react-native/src/components/Picker.md
@@ -78,7 +78,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Picker.re
+++ b/reason-react-native/src/components/Picker.re
@@ -71,7 +71,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/PickerIOS.md
+++ b/reason-react-native/src/components/PickerIOS.md
@@ -72,7 +72,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/PickerIOS.re
+++ b/reason-react-native/src/components/PickerIOS.re
@@ -65,7 +65,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ProgressBarAndroid.md
+++ b/reason-react-native/src/components/ProgressBarAndroid.md
@@ -83,7 +83,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ProgressBarAndroid.re
+++ b/reason-react-native/src/components/ProgressBarAndroid.re
@@ -76,7 +76,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ProgressViewIOS.md
+++ b/reason-react-native/src/components/ProgressViewIOS.md
@@ -75,7 +75,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ProgressViewIOS.re
+++ b/reason-react-native/src/components/ProgressViewIOS.re
@@ -68,7 +68,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/RefreshControl.md
+++ b/reason-react-native/src/components/RefreshControl.md
@@ -78,7 +78,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/RefreshControl.re
+++ b/reason-react-native/src/components/RefreshControl.re
@@ -71,7 +71,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SafeAreaView.md
+++ b/reason-react-native/src/components/SafeAreaView.md
@@ -68,7 +68,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SafeAreaView.re
+++ b/reason-react-native/src/components/SafeAreaView.re
@@ -61,7 +61,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ScrollView.md
+++ b/reason-react-native/src/components/ScrollView.md
@@ -129,7 +129,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ScrollView.re
+++ b/reason-react-native/src/components/ScrollView.re
@@ -122,7 +122,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SectionList.md
+++ b/reason-react-native/src/components/SectionList.md
@@ -185,7 +185,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SectionList.re
+++ b/reason-react-native/src/components/SectionList.re
@@ -178,7 +178,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SegmentedControlIOS.md
+++ b/reason-react-native/src/components/SegmentedControlIOS.md
@@ -82,7 +82,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SegmentedControlIOS.re
+++ b/reason-react-native/src/components/SegmentedControlIOS.re
@@ -75,7 +75,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Slider.md
+++ b/reason-react-native/src/components/Slider.md
@@ -83,7 +83,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Slider.re
+++ b/reason-react-native/src/components/Slider.re
@@ -76,7 +76,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SnapshotViewIOS.md
+++ b/reason-react-native/src/components/SnapshotViewIOS.md
@@ -70,7 +70,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/SnapshotViewIOS.re
+++ b/reason-react-native/src/components/SnapshotViewIOS.re
@@ -63,7 +63,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Switch.md
+++ b/reason-react-native/src/components/Switch.md
@@ -82,7 +82,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/Switch.re
+++ b/reason-react-native/src/components/Switch.re
@@ -75,7 +75,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/TabBarIOS.md
+++ b/reason-react-native/src/components/TabBarIOS.md
@@ -76,7 +76,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [
@@ -186,7 +186,7 @@ module Item = {
       ~onResponderRelease: Event.pressEvent => unit=?,
       ~onResponderStart: Event.pressEvent => unit=?,
       ~onResponderTerminate: Event.pressEvent => unit=?,
-      ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+      ~onResponderTerminationRequest: Event.pressEvent => bool=?,
       ~onStartShouldSetResponder: Event.pressEvent => bool=?,
       ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
       ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/TabBarIOS.re
+++ b/reason-react-native/src/components/TabBarIOS.re
@@ -69,7 +69,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [
@@ -179,7 +179,7 @@ module Item = {
       ~onResponderRelease: Event.pressEvent => unit=?,
       ~onResponderStart: Event.pressEvent => unit=?,
       ~onResponderTerminate: Event.pressEvent => unit=?,
-      ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+      ~onResponderTerminationRequest: Event.pressEvent => bool=?,
       ~onStartShouldSetResponder: Event.pressEvent => bool=?,
       ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
       ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/TextInput.md
+++ b/reason-react-native/src/components/TextInput.md
@@ -290,7 +290,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/TextInput.re
+++ b/reason-react-native/src/components/TextInput.re
@@ -283,7 +283,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ToolbarAndroid.md
+++ b/reason-react-native/src/components/ToolbarAndroid.md
@@ -95,7 +95,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ToolbarAndroid.re
+++ b/reason-react-native/src/components/ToolbarAndroid.re
@@ -88,7 +88,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/View.md
+++ b/reason-react-native/src/components/View.md
@@ -75,7 +75,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/View.re
+++ b/reason-react-native/src/components/View.re
@@ -68,7 +68,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ViewPagerAndroid.md
+++ b/reason-react-native/src/components/ViewPagerAndroid.md
@@ -86,7 +86,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/ViewPagerAndroid.re
+++ b/reason-react-native/src/components/ViewPagerAndroid.re
@@ -79,7 +79,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/VirtualizedList.md
+++ b/reason-react-native/src/components/VirtualizedList.md
@@ -231,7 +231,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/VirtualizedList.re
+++ b/reason-react-native/src/components/VirtualizedList.re
@@ -224,7 +224,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/VirtualizedSectionList.md
+++ b/reason-react-native/src/components/VirtualizedSectionList.md
@@ -206,7 +206,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/VirtualizedSectionList.re
+++ b/reason-react-native/src/components/VirtualizedSectionList.re
@@ -199,7 +199,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/WebView.md
+++ b/reason-react-native/src/components/WebView.md
@@ -146,7 +146,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [

--- a/reason-react-native/src/components/WebView.re
+++ b/reason-react-native/src/components/WebView.re
@@ -139,7 +139,7 @@ external make:
     ~onResponderRelease: Event.pressEvent => unit=?,
     ~onResponderStart: Event.pressEvent => unit=?,
     ~onResponderTerminate: Event.pressEvent => unit=?,
-    ~onResponderTerminationRequest: Event.pressEvent => unit=?,
+    ~onResponderTerminationRequest: Event.pressEvent => bool=?,
     ~onStartShouldSetResponder: Event.pressEvent => bool=?,
     ~onStartShouldSetResponderCapture: Event.pressEvent => bool=?,
     ~pointerEvents: [@bs.string] [


### PR DESCRIPTION
While preparing documentation for `PanResponder`, I realized that the type for the `onResponderTerminationRequest` handler callback is incorrect according to [RN documentation](https://facebook.github.io/react-native/docs/gesture-responder-system)